### PR TITLE
add API to createMPs from user data

### DIFF
--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -111,13 +111,14 @@ void polympo_createMPs(MPMesh_ptr p_mpmesh,
   PMT_ALWAYS_ASSERT(p_mesh->getNumElements() == numElms);
 
   kkIntViewHostU mpsPerElm_h(mpsPerElm,numElms);
-  auto mpsPerElm_d = Kokkos::create_mirror_view_and_copy(Kokkos::DeviceSpace()
+  using space_t = Kokkos::DefaultExecutionSpace::memory_space;
+  auto mpsPerElm_d = Kokkos::create_mirror_view_and_copy(space_t(),
                                                          mpsPerElm_h);
   kkIntViewHostU mp2Elm_h(mp2Elm,numMPs);
-  auto mp2Elm_d = Kokkos::create_mirror_view_and_copy(Kokkos::DeviceSpace()
+  auto mp2Elm_d = Kokkos::create_mirror_view_and_copy(space_t(),
                                                       mp2Elm_h);
-  auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
-  pMPs = new MaterialPoints(numElms, numMPs, mpsPerElm_d, mp2Elm_d);
+  ((polyMPO::MPMesh*)p_mpmesh)->p_MPs =
+     new polyMPO::MaterialPoints(numElms, numMPs, mpsPerElm_d, mp2Elm_d);
 }
 
 void polympo_setMPCurElmID(MPMesh_ptr p_mpmesh,

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -120,7 +120,15 @@ void polympo_createMPs(MPMesh_ptr p_mpmesh,
       break;
     }
   }
-  const auto minElmID = *(std::min_element(mp2Elm, mp2Elm+numMPs));
+
+  int minElmID = numElms+1;
+  for(int i = 0; i < numMPs; i++) {
+    if(isMpActive[i] == MP_ACTIVE) {
+      if(mp2Elm[i] < minElmID) {
+        minElmID = mp2Elm[i];
+      }
+    }
+  }
   int offset = -1;
   if(minElmID-firstElmWithMPs==1) {
     offset = 1;

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -150,15 +150,16 @@ void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh,
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
   PMT_ALWAYS_ASSERT(numMPs == p_MPs->getCount());
   auto mpCurElmID = p_MPs->getData<polyMPO::MPF_Cur_Elm_ID>();
+  auto mpID = p_MPs->getData<polyMPO::MPF_MP_ID>();
 
   kkIntViewHostU arrayHost(elmIDs,numMPs);
   polyMPO::IntView mpCurElmIDCopy("mpCurElmIDNewValue",numMPs);
 
   auto getElmId = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
     if(mask){
-        mpCurElmIDCopy(mp) = mpCurElmID(mp);
+        mpCurElmIDCopy(mpID(mp)) = mpCurElmID(mp);
     }else{
-        mpCurElmIDCopy(mp) = MP_DETACHED;
+        mpCurElmIDCopy(mpID(mp)) = MP_DETACHED;
     }
   };
   p_MPs->parallel_for(getElmId, "get mpCurElmID");

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -169,28 +169,6 @@ void polympo_createMPs(MPMesh_ptr p_mpmesh,
   p_MPs->setElmIDoffset(offset);
 }
 
-void polympo_setMPCurElmID(MPMesh_ptr p_mpmesh,
-                           int numMPs,
-                           int* elmIDs){
-  checkMPMeshValid(p_mpmesh);
-  auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
-  PMT_ALWAYS_ASSERT(numMPs == p_MPs->getCount());
-  auto mpCurElmID = p_MPs->getData<polyMPO::MPF_Cur_Elm_ID>();
-  
-  kkIntViewHostU arrayHost(elmIDs,numMPs);
-  polyMPO::IntView mpCurElmIDCopy("mpCurElmIDNewValue",numMPs);
-  Kokkos::deep_copy(mpCurElmIDCopy,arrayHost);
-
-  auto setVel = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
-    if(mask){
-        mpCurElmID(mp) = mpCurElmIDCopy(mp);
-    }else{
-        mpCurElmID(mp) = MP_DETACHED;
-    }
-  };
-  p_MPs->parallel_for(setVel, "set mpCurElmID");
-}
-
 void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh,
                            int numMPs,
                            int* elmIDs){

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -98,6 +98,28 @@ typedef Kokkos::View<
           Kokkos::MemoryTraits<Kokkos::Unmanaged>
         > kkIntViewHostU;//TODO:put it somewhere else (maybe)
 
+void polympo_createMPs(MPMesh_ptr p_mpmesh,
+                       int numElms,
+                       int numMPs,
+                       int* mpsPerElm,
+                       int* mp2Elm) {
+  checkMPMeshValid(p_mpmesh);
+
+  //the mesh must be fixed/set before adding MPs
+  auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;
+  PMT_ALWAYS_ASSERT(!p_mesh->meshEditable());
+  PMT_ALWAYS_ASSERT(p_mesh->getNumElements() == numElms);
+
+  kkIntViewHostU mpsPerElm_h(mpsPerElm,numElms);
+  auto mpsPerElm_d = Kokkos::create_mirror_view_and_copy(Kokkos::DeviceSpace()
+                                                         mpsPerElm_h);
+  kkIntViewHostU mp2Elm_h(mp2Elm,numMPs);
+  auto mp2Elm_d = Kokkos::create_mirror_view_and_copy(Kokkos::DeviceSpace()
+                                                      mp2Elm_h);
+  auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
+  pMPs = new MaterialPoints(numElms, numMPs, mpsPerElm_d, mp2Elm_d);
+}
+
 void polympo_setMPCurElmID(MPMesh_ptr p_mpmesh,
                            int numMPs,
                            int* elmIDs){

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -1,7 +1,6 @@
 #include "pmpo_createTestMPMesh.hpp"
 #include "pmpo_c.h"
 #include <stdio.h>
-#include <algorithm> //std::min_element
 
 #define MP_DETACHED -1 //TODO: consider other ways later, like enum
 #define MP_ACTIVE 1

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -158,8 +158,6 @@ void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh,
   auto getElmId = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
     if(mask){
         mpCurElmIDCopy(mpID(mp)) = mpCurElmID(mp);
-    }else{
-        mpCurElmIDCopy(mpID(mp)) = MP_DETACHED;
     }
   };
   p_MPs->parallel_for(getElmId, "get mpCurElmID");

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -188,7 +188,7 @@ void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh,
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
   PMT_ALWAYS_ASSERT(numMPs == p_MPs->getCount());
   auto mpCurElmID = p_MPs->getData<polyMPO::MPF_Cur_Elm_ID>();
-  auto mpID = p_MPs->getData<polyMPO::MPF_MP_ID>();
+  auto mpID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();
 
   kkIntViewHostU arrayHost(elmIDs,numMPs);
   polyMPO::IntView mpCurElmIDCopy("mpCurElmIDNewValue",numMPs);

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -113,9 +113,23 @@ void polympo_createMPs(MPMesh_ptr p_mpmesh,
   PMT_ALWAYS_ASSERT(!p_mesh->meshEditable());
   PMT_ALWAYS_ASSERT(p_mesh->getNumElements() == numElms);
 
+  int firstElmWithMPs=-1;
+  for (int i=0; i<numElms; i++) {
+    if(mpsPerElm[i]) {
+      firstElmWithMPs = i;
+      break;
+    }
+  }
   const auto minElmID = *(std::min_element(mp2Elm, mp2Elm+numMPs));
-  //only allow zero or 1 based indexing of local (on process) element ids
-  PMT_ALWAYS_ASSERT(minElmID == 0 || minElmID == 1);
+  int offset = -1;
+  if(minElmID-firstElmWithMPs==1) {
+    offset = 1;
+  }else if (minElmID-firstElmWithMPs==0){
+    offset = 0;
+  }else {
+    fprintf(stderr,"The minElmID is incorrect! Offset is wrong!\n");
+    exit(1);
+  }
 
   std::vector<int> active_mpIDs(numMPs);
   std::vector<int> active_mp2Elm(numMPs);
@@ -123,7 +137,7 @@ void polympo_createMPs(MPMesh_ptr p_mpmesh,
   for(int i=0; i<numMPs; i++) {
     if(isMpActive[i] == MP_ACTIVE) {
       active_mpIDs[numActiveMPs] = i;
-      active_mp2Elm[numActiveMPs] = mp2Elm[i]-minElmID; //adjust for 1 based indexing if needed
+      active_mp2Elm[numActiveMPs] = mp2Elm[i]-offset; //adjust for 1 based indexing if needed
       numActiveMPs++;
     }
   }

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -155,6 +155,7 @@ void polympo_createMPs(MPMesh_ptr p_mpmesh,
   kkIntViewHostU active_mpIDs_h(active_mpIDs.data(),numActiveMPs);
   auto active_mpIDs_d = Kokkos::create_mirror_view_and_copy(space_t(), active_mpIDs_h);
 
+  delete ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
   ((polyMPO::MPMesh*)p_mpmesh)->p_MPs =
      new polyMPO::MaterialPoints(numElms, numActiveMPs, mpsPerElm_d, active_mp2Elm_d, active_mpIDs_d);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -186,7 +186,7 @@ void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh,
                            int* elmIDs){
   checkMPMeshValid(p_mpmesh);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
-  PMT_ALWAYS_ASSERT(numMPs == p_MPs->getCount());
+  PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getCount());
   auto mpCurElmID = p_MPs->getData<polyMPO::MPF_Cur_Elm_ID>();
   auto mpID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();
 
@@ -195,7 +195,7 @@ void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh,
 
   auto getElmId = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
     if(mask){
-        mpCurElmIDCopy(mpID(mp)) = mpCurElmID(mp);
+        mpCurElmIDCopy(mpID(mp)) = mpCurElmID(mp);//TODO: we need add a flag if we need +1 or not
     }
   };
   p_MPs->parallel_for(getElmId, "get mpCurElmID");

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -4,6 +4,7 @@
 #include <algorithm> //std::min_element
 
 #define MP_DETACHED -1 //TODO: consider other ways later, like enum
+#define MP_ACTIVE 1
 
 namespace{
   std::vector<MPMesh_ptr> p_mpmeshes;////store the p_mpmeshes that is legal
@@ -120,7 +121,7 @@ void polympo_createMPs(MPMesh_ptr p_mpmesh,
   std::vector<int> active_mp2Elm(numMPs);
   int numActiveMPs = 0;
   for(int i=0; i<numMPs; i++) {
-    if(isMpActive[i]==1) {
+    if(isMpActive[i] == MP_ACTIVE) {
       active_mpIDs[numActiveMPs] = i;
       active_mp2Elm[numActiveMPs] = mp2Elm[i]-minElmID; //adjust for 1 based indexing if needed
       numActiveMPs++;

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -154,14 +154,14 @@ void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh,
   kkIntViewHostU arrayHost(elmIDs,numMPs);
   polyMPO::IntView mpCurElmIDCopy("mpCurElmIDNewValue",numMPs);
 
-  auto setVel = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
+  auto getElmId = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
     if(mask){
         mpCurElmIDCopy(mp) = mpCurElmID(mp);
     }else{
         mpCurElmIDCopy(mp) = MP_DETACHED;
     }
   };
-  p_MPs->parallel_for(setVel, "get mpCurElmID");
+  p_MPs->parallel_for(getElmId, "get mpCurElmID");
   Kokkos::deep_copy( arrayHost, mpCurElmIDCopy);
 }
 

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -104,7 +104,7 @@ void polympo_createMPs(MPMesh_ptr p_mpmesh,
                        int numMPs, // >= number of active MPs
                        int* mpsPerElm,
                        int* mp2Elm,
-                       int* isMpActive) {
+                       int* isMPActive) {
   checkMPMeshValid(p_mpmesh);
 
   //the mesh must be fixed/set before adding MPs
@@ -122,7 +122,7 @@ void polympo_createMPs(MPMesh_ptr p_mpmesh,
 
   int minElmID = numElms+1;
   for(int i = 0; i < numMPs; i++) {
-    if(isMpActive[i] == MP_ACTIVE) {
+    if(isMPActive[i] == MP_ACTIVE) {
       if(mp2Elm[i] < minElmID) {
         minElmID = mp2Elm[i];
       }
@@ -142,7 +142,7 @@ void polympo_createMPs(MPMesh_ptr p_mpmesh,
   std::vector<int> active_mp2Elm(numMPs);
   int numActiveMPs = 0;
   for(int i=0; i<numMPs; i++) {
-    if(isMpActive[i] == MP_ACTIVE) {
+    if(isMPActive[i] == MP_ACTIVE) {
       active_mpIDs[numActiveMPs] = i;
       active_mp2Elm[numActiveMPs] = mp2Elm[i]-offset; //adjust for 1 based indexing if needed
       numActiveMPs++;

--- a/src/pmpo_c.h
+++ b/src/pmpo_c.h
@@ -20,7 +20,7 @@ void polympo_setMPICommunicator(MPI_Fint fcomm);//TODO:is MPI_Fint best? or some
 //TODO: add a function to get communicator
 
 //MP info
-void polympo_createMPs(MPMesh_ptr p_mpmesh, int numElms, int numMPs, int* mpsPerElm, int* mp2Elm, int* isMPActive);
+void polympo_createMPs(MPMesh_ptr p_mpmesh, int numElms, int numMPs, int* mpsPerElm, int* mp2Elm, int* mpAppID);
 void polympo_setMPCurElmID(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs); //FIXME remove
 void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs);
 void polympo_getMPPositions(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);

--- a/src/pmpo_c.h
+++ b/src/pmpo_c.h
@@ -20,7 +20,8 @@ void polympo_setMPICommunicator(MPI_Fint fcomm);//TODO:is MPI_Fint best? or some
 //TODO: add a function to get communicator
 
 //MP info
-void polympo_setMPCurElmID(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs);
+void polympo_createMPs(MPMesh_ptr p_mpmesh, int numElms, int numMPs, int* mpsPerElm, int* mp2Elm);
+void polympo_setMPCurElmID(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs); //FIXME remove
 void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs);
 void polympo_getMPPositions(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);
 

--- a/src/pmpo_c.h
+++ b/src/pmpo_c.h
@@ -20,7 +20,7 @@ void polympo_setMPICommunicator(MPI_Fint fcomm);//TODO:is MPI_Fint best? or some
 //TODO: add a function to get communicator
 
 //MP info
-void polympo_createMPs(MPMesh_ptr p_mpmesh, int numElms, int numMPs, int* mpsPerElm, int* mp2Elm);
+void polympo_createMPs(MPMesh_ptr p_mpmesh, int numElms, int numMPs, int* mpsPerElm, int* mp2Elm, int* isMPActive);
 void polympo_setMPCurElmID(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs); //FIXME remove
 void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs);
 void polympo_getMPPositions(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);

--- a/src/pmpo_c.h
+++ b/src/pmpo_c.h
@@ -21,7 +21,6 @@ void polympo_setMPICommunicator(MPI_Fint fcomm);//TODO:is MPI_Fint best? or some
 
 //MP info
 void polympo_createMPs(MPMesh_ptr p_mpmesh, int numElms, int numMPs, int* mpsPerElm, int* mp2Elm, int* isMPActive);
-void polympo_setMPCurElmID(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs); //FIXME remove
 void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs);
 void polympo_getMPPositions(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);
 

--- a/src/pmpo_c.h
+++ b/src/pmpo_c.h
@@ -20,7 +20,7 @@ void polympo_setMPICommunicator(MPI_Fint fcomm);//TODO:is MPI_Fint best? or some
 //TODO: add a function to get communicator
 
 //MP info
-void polympo_createMPs(MPMesh_ptr p_mpmesh, int numElms, int numMPs, int* mpsPerElm, int* mp2Elm, int* mpAppID);
+void polympo_createMPs(MPMesh_ptr p_mpmesh, int numElms, int numMPs, int* mpsPerElm, int* mp2Elm, int* isMPActive);
 void polympo_setMPCurElmID(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs); //FIXME remove
 void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs);
 void polympo_getMPPositions(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -71,19 +71,6 @@ module polympo
     type(c_ptr), intent(in), value :: isMPActive
   end subroutine
   !---------------------------------------------------------------------------
-  !> @brief set the MP current element array from a host array
-  !> @param mpmesh(in/out) MPMesh object
-  !> @param numMPs(in) length of array, number of the MPs
-  !> @param array(in) input MP element ID 1D array (numMPs)
-  !---------------------------------------------------------------------------
-  subroutine polympo_setMPCurElmID(mpMesh, numMPs, array) &
-             bind(C, NAME='polympo_setMPCurElmID')
-    use :: iso_c_binding
-    type(c_ptr), value :: mpMesh
-    integer(c_int), value :: numMPs
-    type(c_ptr), intent(in), value :: array
-  end subroutine
-  !---------------------------------------------------------------------------
   !> @brief get the current element ID MP array from a polympo array
   !> @param mpmesh(in/out) MPMesh object
   !> @param numMPs(in) length of array, number of the MPs

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -55,7 +55,7 @@ module polympo
   !> @brief the fields associated with the MPs are NOT initialized
   !> @param mpmesh(in/out) MPMesh object
   !> @param numElms(in) total number of mesh elements
-  !> @param numMPs(in) total number of MPs
+  !> @param numMPs(in) total number of MPs, total = number of active + number of inactive
   !> @param mpsPerElm(in) number of MPs per mesh element
   !> @param mp2Elm(in) element ID for each MP
   !> @param isMpActive(in) set to 1 if the MP is active, 0 otherwise

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -51,6 +51,24 @@ module polympo
     integer(c_int), value :: comm    
   end subroutine
   !---------------------------------------------------------------------------
+  !> @brief create the material points
+  !> @brief the fields associated with the MPs are NOT initialized
+  !> @param mpmesh(in/out) MPMesh object
+  !> @param numElms(in) total number of mesh elements
+  !> @param numMPs(in) total number of MPs
+  !> @param mpsPerElm(in) number of MPs per mesh element
+  !> @param mp2Elm(in) element ID for each MP
+  !---------------------------------------------------------------------------
+  subroutine polympo_createMPs(mpMesh, numElms, numMPs, mpsPerElm, mp2Elm) &
+             bind(C, NAME='polympo_createMPs')
+    use :: iso_c_binding
+    type(c_ptr), value :: mpMesh
+    integer(c_int), value :: numElms
+    integer(c_int), value :: numMPs
+    type(c_ptr), intent(in), value :: mpsPerElm
+    type(c_ptr), intent(in), value :: mp2Elm
+  end subroutine
+  !---------------------------------------------------------------------------
   !> @brief set the MP current element array from a host array
   !> @param mpmesh(in/out) MPMesh object
   !> @param numMPs(in) length of array, number of the MPs

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -56,7 +56,7 @@ module polympo
   !> @param mpmesh(in/out) MPMesh object
   !> @param numElms(in) total number of mesh elements
   !> @param numMPs(in) total number of MPs, total = number of active + number of inactive
-  !> @param mpsPerElm(in) number of MPs per mesh element
+  !> @param mpsPerElm(in) number of MPs for each mesh element
   !> @param mp2Elm(in) element ID for each MP
   !> @param isMpActive(in) set to 1 if the MP is active, 0 otherwise
   !---------------------------------------------------------------------------

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -58,6 +58,7 @@ module polympo
   !> @param numMPs(in) total number of MPs
   !> @param mpsPerElm(in) number of MPs per mesh element
   !> @param mp2Elm(in) element ID for each MP
+  !> @param isMpActive(in) set to 1 if the MP is active, 0 otherwise
   !---------------------------------------------------------------------------
   subroutine polympo_createMPs(mpMesh, numElms, numMPs, mpsPerElm, mp2Elm, isMpActive) &
              bind(C, NAME='polympo_createMPs')

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -58,9 +58,9 @@ module polympo
   !> @param numMPs(in) total number of MPs, total = number of active + number of inactive
   !> @param mpsPerElm(in) number of MPs for each mesh element
   !> @param mp2Elm(in) element ID for each MP
-  !> @param isMpActive(in) set to 1 if the MP is active, 0 otherwise
+  !> @param isMPActive(in) set to 1 if the MP is active, 0 otherwise
   !---------------------------------------------------------------------------
-  subroutine polympo_createMPs(mpMesh, numElms, numMPs, mpsPerElm, mp2Elm, isMpActive) &
+  subroutine polympo_createMPs(mpMesh, numElms, numMPs, mpsPerElm, mp2Elm, isMPActive) &
              bind(C, NAME='polympo_createMPs')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
@@ -68,7 +68,7 @@ module polympo
     integer(c_int), value :: numMPs
     type(c_ptr), intent(in), value :: mpsPerElm
     type(c_ptr), intent(in), value :: mp2Elm
-    type(c_ptr), intent(in), value :: isMpActive
+    type(c_ptr), intent(in), value :: isMPActive
   end subroutine
   !---------------------------------------------------------------------------
   !> @brief set the MP current element array from a host array

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -59,7 +59,7 @@ module polympo
   !> @param mpsPerElm(in) number of MPs per mesh element
   !> @param mp2Elm(in) element ID for each MP
   !---------------------------------------------------------------------------
-  subroutine polympo_createMPs(mpMesh, numElms, numMPs, mpsPerElm, mp2Elm) &
+  subroutine polympo_createMPs(mpMesh, numElms, numMPs, mpsPerElm, mp2Elm, isMpActive) &
              bind(C, NAME='polympo_createMPs')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
@@ -67,6 +67,7 @@ module polympo
     integer(c_int), value :: numMPs
     type(c_ptr), intent(in), value :: mpsPerElm
     type(c_ptr), intent(in), value :: mp2Elm
+    type(c_ptr), intent(in), value :: isMpActive
   end subroutine
   !---------------------------------------------------------------------------
   !> @brief set the MP current element array from a host array

--- a/src/pmpo_materialPoints.cpp
+++ b/src/pmpo_materialPoints.cpp
@@ -21,16 +21,16 @@ PS* createDPS(int numElms, int numMPs, DoubleVec3dView positions, IntView mpsPer
   return dps;
 }
 
-PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView mpID) {
+PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView mpAppID) {
   PS::kkGidView elmGids("elementGlobalIds", numElms); //TODO - initialize this to [0..numElms)
   auto mpInfo = ps::createMemberViews<MaterialPointTypes>(numMPs);
   auto mpCurElmPos_m = ps::getMemberView<MaterialPointTypes, MPF_Cur_Elm_ID>(mpInfo);
-  auto mpID_m = ps::getMemberView<MaterialPointTypes, MPF_MP_ID>(mpInfo);
+  auto mpAppID_m = ps::getMemberView<MaterialPointTypes, MPF_MP_APP_ID>(mpInfo);
   auto mpStatus_m = ps::getMemberView<MaterialPointTypes, MPF_Status>(mpInfo);
   Kokkos::parallel_for("setMPinfo", numMPs, KOKKOS_LAMBDA(int i) {
     mpCurElmPos_m(i) = mp2elm(i);
     mpStatus_m(i) = 1;
-    mpID_m(i) = mpID(i);
+    mpAppID_m(i) = mpAppID(i);
   });
   Kokkos::TeamPolicy<Kokkos::DefaultExecutionSpace> policy(numElms,Kokkos::AUTO);
   auto dps = new DPS<MaterialPointTypes>(policy, numElms, numMPs, mpsPerElm, elmGids, mp2elm, mpInfo);

--- a/src/pmpo_materialPoints.cpp
+++ b/src/pmpo_materialPoints.cpp
@@ -21,16 +21,16 @@ PS* createDPS(int numElms, int numMPs, DoubleVec3dView positions, IntView mpsPer
   return dps;
 }
 
-PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm) {
+PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView mpID) {
   PS::kkGidView elmGids("elementGlobalIds", numElms); //TODO - initialize this to [0..numElms)
   auto mpInfo = ps::createMemberViews<MaterialPointTypes>(numMPs);
-  auto mpCurElmPos = ps::getMemberView<MaterialPointTypes, MPF_Cur_Elm_ID>(mpInfo);
-  auto mpID = ps::getMemberView<MaterialPointTypes, MPF_MP_ID>(mpInfo);
-  auto mpStatus = ps::getMemberView<MaterialPointTypes, MPF_Status>(mpInfo);
+  auto mpCurElmPos_m = ps::getMemberView<MaterialPointTypes, MPF_Cur_Elm_ID>(mpInfo);
+  auto mpID_m = ps::getMemberView<MaterialPointTypes, MPF_MP_ID>(mpInfo);
+  auto mpStatus_m = ps::getMemberView<MaterialPointTypes, MPF_Status>(mpInfo);
   Kokkos::parallel_for("setMPinfo", numMPs, KOKKOS_LAMBDA(int i) {
-    mpCurElmPos(i) = mp2elm(i);
-    mpStatus(i) = 1;
-    mpID(i) = i;
+    mpCurElmPos_m(i) = mp2elm(i);
+    mpStatus_m(i) = 1;
+    mpID_m(i) = mpID(i);
   });
   Kokkos::TeamPolicy<Kokkos::DefaultExecutionSpace> policy(numElms,Kokkos::AUTO);
   auto dps = new DPS<MaterialPointTypes>(policy, numElms, numMPs, mpsPerElm, elmGids, mp2elm, mpInfo);

--- a/src/pmpo_materialPoints.cpp
+++ b/src/pmpo_materialPoints.cpp
@@ -25,10 +25,12 @@ PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm) {
   PS::kkGidView elmGids("elementGlobalIds", numElms); //TODO - initialize this to [0..numElms)
   auto mpInfo = ps::createMemberViews<MaterialPointTypes>(numMPs);
   auto mpCurElmPos = ps::getMemberView<MaterialPointTypes, MPF_Cur_Elm_ID>(mpInfo);
+  auto mpID = ps::getMemberView<MaterialPointTypes, MPF_MP_ID>(mpInfo);
   auto mpStatus = ps::getMemberView<MaterialPointTypes, MPF_Status>(mpInfo);
   Kokkos::parallel_for("setMPinfo", numMPs, KOKKOS_LAMBDA(int i) {
     mpCurElmPos(i) = mp2elm(i);
     mpStatus(i) = 1;
+    mpID(i) = i;
   });
   Kokkos::TeamPolicy<Kokkos::DefaultExecutionSpace> policy(numElms,Kokkos::AUTO);
   auto dps = new DPS<MaterialPointTypes>(policy, numElms, numMPs, mpsPerElm, elmGids, mp2elm, mpInfo);

--- a/src/pmpo_materialPoints.hpp
+++ b/src/pmpo_materialPoints.hpp
@@ -100,6 +100,7 @@ PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntVie
 class MaterialPoints {
   private:
     PS* MPs;
+    int elmIDoffset = -1; //CHECK THIS
 
   public:
     MaterialPoints() : MPs(nullptr) {};
@@ -169,6 +170,15 @@ class MaterialPoints {
     }
     int getCount() { return MPs->nPtcls(); }
     auto getPositions() { return getData<MPF_Cur_Pos_XYZ>(); }
+
+    void setElmIDoffset(int offset) {
+      PMT_ALWAYS_ASSERT(offset == 0 || offset == 1);
+      elmIDoffset = offset;
+    }
+    int getElmIDoffset() {
+      PMT_ALWAYS_ASSERT(elmIDoffset == 0 || elmIDoffset == 1);
+      return elmIDoffset;
+    }
 
 //MUTATOR  
     template <MaterialPointSlice index> void fillData(double value);//use PS_LAMBDA fill up to 1

--- a/src/pmpo_materialPoints.hpp
+++ b/src/pmpo_materialPoints.hpp
@@ -107,8 +107,8 @@ class MaterialPoints {
     MaterialPoints(int numElms, int numMPs, DoubleVec3dView positions, IntView mpsPerElm, IntView mp2elm) {
       MPs = createDPS(numElms, numMPs, positions, mpsPerElm, mp2elm);
     };
-    MaterialPoints(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView mpAppID) {
-      MPs = createDPS(numElms, numMPs, mpsPerElm, mp2elm, mpAppID);
+    MaterialPoints(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView isMPActive) {
+      MPs = createDPS(numElms, numMPs, mpsPerElm, mp2elm, isMPActive);
     };
     ~MaterialPoints() {
       if(MPs != nullptr)

--- a/src/pmpo_materialPoints.hpp
+++ b/src/pmpo_materialPoints.hpp
@@ -16,6 +16,7 @@ using particle_structs::MemberTypes;
 
 //typedef bool mp_flag_t;
 typedef int mp_flag_t;
+typedef int mp_id_t;
 typedef int  mp_elm_id_t;
 typedef double mp_sclr_t[1];//TODO
 typedef vec2d_t mp_vec2d_t;
@@ -42,7 +43,8 @@ enum MaterialPointSlice {
   MPF_Stress,
   MPF_Stress_Div,
   MPF_Shear_Traction,    //15
-  MPF_Constv_Mdl_Param
+  MPF_Constv_Mdl_Param,
+  MPF_MP_ID
 };
 
 const static std::map<MaterialPointSlice, std::pair<int,MeshFieldIndex>> 
@@ -62,7 +64,8 @@ const static std::map<MaterialPointSlice, std::pair<int,MeshFieldIndex>>
                            {MPF_Stress,          {6,MeshF_Unsupported}},
                            {MPF_Stress_Div,      {3,MeshF_Unsupported}},
                            {MPF_Shear_Traction,  {3,MeshF_Unsupported}},
-                           {MPF_Constv_Mdl_Param,{12,MeshF_Unsupported}}};
+                           {MPF_Constv_Mdl_Param,{12,MeshF_Unsupported}},
+                           {MPF_MP_ID,           {1,MeshF_Invalid}}};
 
 const static std::vector<std::pair<MaterialPointSlice, MaterialPointSlice>>
         mpSliceSwap = {{MPF_Cur_Elm_ID, MPF_Tgt_Elm_ID},
@@ -85,7 +88,8 @@ typedef MemberTypes<mp_flag_t,              //MP_Status
                     mp_sym_mat3d_t,         //MP_Stress
                     mp_vec3d_t,             //MP_Stress_Div
                     mp_vec3d_t,             //MP_Shear_Traction
-                    mp_constv_mdl_param_t   //MP_Constv_Mdl_Param
+                    mp_constv_mdl_param_t,  //MP_Constv_Mdl_Param
+                    mp_id_t                 //MP_ID
                     >MaterialPointTypes;
 typedef ps::ParticleStructure<MaterialPointTypes> PS;
 

--- a/src/pmpo_materialPoints.hpp
+++ b/src/pmpo_materialPoints.hpp
@@ -95,7 +95,7 @@ typedef ps::ParticleStructure<MaterialPointTypes> PS;
 
 
 PS* createDPS(int numElms, int numMPs, DoubleVec3dView positions, IntView mpsPerElm, IntView mp2elm);
-PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView mpAppID);
+PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView isMPActive);
 
 class MaterialPoints {
   private:

--- a/src/pmpo_materialPoints.hpp
+++ b/src/pmpo_materialPoints.hpp
@@ -100,7 +100,7 @@ PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntVie
 class MaterialPoints {
   private:
     PS* MPs;
-    int elmIDoffset = -1; //CHECK THIS
+    int elmIDoffset = -1;
 
   public:
     MaterialPoints() : MPs(nullptr) {};

--- a/src/pmpo_materialPoints.hpp
+++ b/src/pmpo_materialPoints.hpp
@@ -95,7 +95,7 @@ typedef ps::ParticleStructure<MaterialPointTypes> PS;
 
 
 PS* createDPS(int numElms, int numMPs, DoubleVec3dView positions, IntView mpsPerElm, IntView mp2elm);
-PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm);
+PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView isMPActive);
 
 class MaterialPoints {
   private:
@@ -106,8 +106,8 @@ class MaterialPoints {
     MaterialPoints(int numElms, int numMPs, DoubleVec3dView positions, IntView mpsPerElm, IntView mp2elm) {
       MPs = createDPS(numElms, numMPs, positions, mpsPerElm, mp2elm);
     };
-    MaterialPoints(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm) {
-      MPs = createDPS(numElms, numMPs, mpsPerElm, mp2elm);
+    MaterialPoints(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView isMPActive) {
+      MPs = createDPS(numElms, numMPs, mpsPerElm, mp2elm, isMPActive);
     };
     ~MaterialPoints() {
       if(MPs != nullptr)

--- a/src/pmpo_materialPoints.hpp
+++ b/src/pmpo_materialPoints.hpp
@@ -44,7 +44,7 @@ enum MaterialPointSlice {
   MPF_Stress_Div,
   MPF_Shear_Traction,    //15
   MPF_Constv_Mdl_Param,
-  MPF_MP_ID
+  MPF_MP_APP_ID
 };
 
 const static std::map<MaterialPointSlice, std::pair<int,MeshFieldIndex>> 
@@ -65,7 +65,7 @@ const static std::map<MaterialPointSlice, std::pair<int,MeshFieldIndex>>
                            {MPF_Stress_Div,      {3,MeshF_Unsupported}},
                            {MPF_Shear_Traction,  {3,MeshF_Unsupported}},
                            {MPF_Constv_Mdl_Param,{12,MeshF_Unsupported}},
-                           {MPF_MP_ID,           {1,MeshF_Invalid}}};
+                           {MPF_MP_APP_ID,       {1,MeshF_Invalid}}};
 
 const static std::vector<std::pair<MaterialPointSlice, MaterialPointSlice>>
         mpSliceSwap = {{MPF_Cur_Elm_ID, MPF_Tgt_Elm_ID},
@@ -89,13 +89,13 @@ typedef MemberTypes<mp_flag_t,              //MP_Status
                     mp_vec3d_t,             //MP_Stress_Div
                     mp_vec3d_t,             //MP_Shear_Traction
                     mp_constv_mdl_param_t,  //MP_Constv_Mdl_Param
-                    mp_id_t                 //MP_ID
+                    mp_id_t                 //MP_APP_ID
                     >MaterialPointTypes;
 typedef ps::ParticleStructure<MaterialPointTypes> PS;
 
 
 PS* createDPS(int numElms, int numMPs, DoubleVec3dView positions, IntView mpsPerElm, IntView mp2elm);
-PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView isMPActive);
+PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView mpAppID);
 
 class MaterialPoints {
   private:
@@ -106,8 +106,8 @@ class MaterialPoints {
     MaterialPoints(int numElms, int numMPs, DoubleVec3dView positions, IntView mpsPerElm, IntView mp2elm) {
       MPs = createDPS(numElms, numMPs, positions, mpsPerElm, mp2elm);
     };
-    MaterialPoints(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView isMPActive) {
-      MPs = createDPS(numElms, numMPs, mpsPerElm, mp2elm, isMPActive);
+    MaterialPoints(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView mpAppID) {
+      MPs = createDPS(numElms, numMPs, mpsPerElm, mp2elm, mpAppID);
     };
     ~MaterialPoints() {
       if(MPs != nullptr)

--- a/src/pmpo_materialPoints.hpp
+++ b/src/pmpo_materialPoints.hpp
@@ -91,6 +91,7 @@ typedef ps::ParticleStructure<MaterialPointTypes> PS;
 
 
 PS* createDPS(int numElms, int numMPs, DoubleVec3dView positions, IntView mpsPerElm, IntView mp2elm);
+PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm);
 
 class MaterialPoints {
   private:

--- a/src/pmpo_materialPoints.hpp
+++ b/src/pmpo_materialPoints.hpp
@@ -101,6 +101,9 @@ class MaterialPoints {
     MaterialPoints(int numElms, int numMPs, DoubleVec3dView positions, IntView mpsPerElm, IntView mp2elm) {
       MPs = createDPS(numElms, numMPs, positions, mpsPerElm, mp2elm);
     };
+    MaterialPoints(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm) {
+      MPs = createDPS(numElms, numMPs, mpsPerElm, mp2elm);
+    };
     ~MaterialPoints() {
       if(MPs != nullptr)
         delete MPs;

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -85,12 +85,10 @@ subroutine loadMPASMesh(mpMesh, filename)
     call polympo_createMPs(mpMesh,nCells,numMPs,c_loc(mpsPerElm),c_loc(mp2Elm));
     mp2Elm = -99
     call polympo_getMPCurElmID(mpMesh,numMPs,c_loc(mp2Elm))
-    write(*,*) "i mp2Elm(i)", 1, mp2Elm(1)
     call assert(mp2Elm(1) .eq. 0, "wrong element ID for MP 1")
     call assert(mp2Elm(2) .eq. 1, "wrong element ID for MP 2")
     call assert(mp2Elm(3) .eq. 1, "wrong element ID for MP 3")
     do i = 4,numMPs
-      write(*,*) "i mp2Elm(i)", i, mp2Elm(i)
       call assert(mp2Elm(i) .eq. i-2, "wrong element ID for i'th MP")
     end do
 

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -71,24 +71,27 @@ subroutine loadMPASMesh(mpMesh, filename)
 
     !create MPs
     call assert(nCells .ge. 2, "This test requires a mesh with at least two cells")
-    numMPs = nCells;
+    numMPs = nCells+1;
     allocate(mpsPerElm(nCells))
     allocate(mp2Elm(numMPs))
     mpsPerElm = 1
-    !mp2Elm(1) = 0 !pumpic wants zero based cell indices/numbering/IDs
-    !mp2Elm(2) = 1
-    !mp2Elm(3) = 1
-    do i = 1,numMPs
-      mp2Elm(i) = i
+    mpsPerElm(2) = 2
+    mp2Elm(1) = 0 !pumpic wants zero based cell indices/numbering/IDs
+    mp2Elm(2) = 1
+    mp2Elm(3) = 1
+    do i = 4,numMPs
+      mp2Elm(i) = i-2
     end do
     call polympo_createMPs(mpMesh,nCells,numMPs,c_loc(mpsPerElm),c_loc(mp2Elm));
-    mp2Elm = -1
+    mp2Elm = -99
     call polympo_getMPCurElmID(mpMesh,numMPs,c_loc(mp2Elm))
-    !call assert(mp2Elm(1) .eq. 0, "wrong element ID for MP 1")
-    !call assert(mp2Elm(2) .eq. 1, "wrong element ID for MP 2")
-    !call assert(mp2Elm(3) .eq. 1, "wrong element ID for MP 3")
-    do i = 1,numMPs
-      call assert(mp2Elm(i) .eq. i, "wrong element ID for i'th MP")
+    write(*,*) "i mp2Elm(i)", 1, mp2Elm(1)
+    call assert(mp2Elm(1) .eq. 0, "wrong element ID for MP 1")
+    call assert(mp2Elm(2) .eq. 1, "wrong element ID for MP 2")
+    call assert(mp2Elm(3) .eq. 1, "wrong element ID for MP 3")
+    do i = 4,numMPs
+      write(*,*) "i mp2Elm(i)", i, mp2Elm(i)
+      call assert(mp2Elm(i) .eq. i-2, "wrong element ID for i'th MP")
     end do
 
     !set vtxCoords which is a mesh field 

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -71,18 +71,25 @@ subroutine loadMPASMesh(mpMesh, filename)
 
     !create MPs
     call assert(nCells .ge. 2, "This test requires a mesh with at least two cells")
-    numMPs = nCells+1;
+    numMPs = nCells;
     allocate(mpsPerElm(nCells))
     allocate(mp2Elm(numMPs))
     mpsPerElm = 1
-    mpsPerElm(2) = 2
-    mp2Elm(1) = 0 !pumpic wants zero based cell indices/numbering/IDs
-    mp2Elm(2) = 1
-    mp2Elm(3) = 1
-    do i = 4,numMPs
-      mp2Elm(i) = i-2
+    !mp2Elm(1) = 0 !pumpic wants zero based cell indices/numbering/IDs
+    !mp2Elm(2) = 1
+    !mp2Elm(3) = 1
+    do i = 1,numMPs
+      mp2Elm(i) = i
     end do
     call polympo_createMPs(mpMesh,nCells,numMPs,c_loc(mpsPerElm),c_loc(mp2Elm));
+    mp2Elm = -1
+    call polympo_getMPCurElmID(mpMesh,numMPs,c_loc(mp2Elm))
+    !call assert(mp2Elm(1) .eq. 0, "wrong element ID for MP 1")
+    !call assert(mp2Elm(2) .eq. 1, "wrong element ID for MP 2")
+    !call assert(mp2Elm(3) .eq. 1, "wrong element ID for MP 3")
+    do i = 1,numMPs
+      call assert(mp2Elm(i) .eq. i, "wrong element ID for i'th MP")
+    end do
 
     !set vtxCoords which is a mesh field 
     call polympo_setMeshVtxCoords(mpMesh,nVertices,c_loc(xVertex),c_loc(yVertex),c_loc(zVertex))

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -35,7 +35,7 @@ subroutine loadMPASMesh(mpMesh, filename)
     integer, dimension(:), pointer :: nEdgesOnCell
     real(kind=MPAS_RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
     integer, dimension(:,:), pointer :: verticesOnCell, cellsOnCell
-    integer, dimension(:), pointer :: mpsPerElm, mp2Elm, isMPActive
+    integer, dimension(:), pointer :: mpsPerElm, mp2Elm, mpAppID
     
     call readMPASMesh(trim(filename), maxEdges, vertexDegree, &
                               nCells, nVertices, nEdgesOnCell, &
@@ -74,8 +74,8 @@ subroutine loadMPASMesh(mpMesh, filename)
     numMPs = nCells+1;
     allocate(mpsPerElm(nCells))
     allocate(mp2Elm(numMPs))
-    allocate(isMPActive(numMPs))
-    isMPActive = 1 !no inactive MPs
+    allocate(mpAppID(numMPs))
+    mpAppID = 1 !no inactive MPs
     mpsPerElm = 1
     mpsPerElm(2) = 2
     mp2Elm(1) = 0 !pumpic wants zero based cell indices/numbering/IDs
@@ -84,7 +84,7 @@ subroutine loadMPASMesh(mpMesh, filename)
     do i = 4,numMPs
       mp2Elm(i) = i-2
     end do
-    call polympo_createMPs(mpMesh,nCells,numMPs,c_loc(mpsPerElm),c_loc(mp2Elm),c_loc(isMPActive));
+    call polympo_createMPs(mpMesh,nCells,numMPs,c_loc(mpsPerElm),c_loc(mp2Elm),c_loc(mpAppID));
     mp2Elm = -99
     call polympo_getMPCurElmID(mpMesh,numMPs,c_loc(mp2Elm))
     call assert(mp2Elm(1) .eq. 0, "wrong element ID for MP 1")

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -35,7 +35,7 @@ subroutine loadMPASMesh(mpMesh, filename)
     integer, dimension(:), pointer :: nEdgesOnCell
     real(kind=MPAS_RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
     integer, dimension(:,:), pointer :: verticesOnCell, cellsOnCell
-    integer, dimension(:), pointer :: mpsPerElm, mp2Elm
+    integer, dimension(:), pointer :: mpsPerElm, mp2Elm, isMPActive
     
     call readMPASMesh(trim(filename), maxEdges, vertexDegree, &
                               nCells, nVertices, nEdgesOnCell, &
@@ -74,6 +74,8 @@ subroutine loadMPASMesh(mpMesh, filename)
     numMPs = nCells+1;
     allocate(mpsPerElm(nCells))
     allocate(mp2Elm(numMPs))
+    allocate(isMPActive(numMPs))
+    isMPActive = 1 !no inactive MPs
     mpsPerElm = 1
     mpsPerElm(2) = 2
     mp2Elm(1) = 0 !pumpic wants zero based cell indices/numbering/IDs
@@ -82,7 +84,7 @@ subroutine loadMPASMesh(mpMesh, filename)
     do i = 4,numMPs
       mp2Elm(i) = i-2
     end do
-    call polympo_createMPs(mpMesh,nCells,numMPs,c_loc(mpsPerElm),c_loc(mp2Elm));
+    call polympo_createMPs(mpMesh,nCells,numMPs,c_loc(mpsPerElm),c_loc(mp2Elm),c_loc(isMPActive));
     mp2Elm = -99
     call polympo_getMPCurElmID(mpMesh,numMPs,c_loc(mp2Elm))
     call assert(mp2Elm(1) .eq. 0, "wrong element ID for MP 1")

--- a/test/testFortran.f90
+++ b/test/testFortran.f90
@@ -65,16 +65,6 @@ program main
     call assert(abs(MPPositions(3,i) - 1.1) .lt. test_epsilon, "Assert zPositions for MP array Fail")
   end do
 
-  !do i = 1,numMPs 
-  !  MPElmID(i) = mod(i, numElms)
-  !end do
-  !call polympo_setMPCurElmID(mpMesh, numMPs, c_loc(MPElmID))
-  !MPElmID = 0
-  !call polympo_getMPCurElmID(mpMesh, numMPs, c_loc(MPElmID))
-  !do i = 1,numMPs 
-  !  call assert((MPElmID(i) .eq. mod(i, numElms)) , "Assert MPElmID Fail")
-  !end do
-
   do i = 1,numCompsVel
     do j = 1,nverts 
         Mesharray(i,j) = (i-1)*numCompsVel + j

--- a/test/testFortran.f90
+++ b/test/testFortran.f90
@@ -65,15 +65,15 @@ program main
     call assert(abs(MPPositions(3,i) - 1.1) .lt. test_epsilon, "Assert zPositions for MP array Fail")
   end do
 
-  do i = 1,numMPs 
-    MPElmID(i) = mod(i, numElms)
-  end do
-  call polympo_setMPCurElmID(mpMesh, numMPs, c_loc(MPElmID))
-  MPElmID = 0
-  call polympo_getMPCurElmID(mpMesh, numMPs, c_loc(MPElmID))
-  do i = 1,numMPs 
-    call assert((MPElmID(i) .eq. mod(i, numElms)) , "Assert MPElmID Fail")
-  end do
+  !do i = 1,numMPs 
+  !  MPElmID(i) = mod(i, numElms)
+  !end do
+  !call polympo_setMPCurElmID(mpMesh, numMPs, c_loc(MPElmID))
+  !MPElmID = 0
+  !call polympo_getMPCurElmID(mpMesh, numMPs, c_loc(MPElmID))
+  !do i = 1,numMPs 
+  !  call assert((MPElmID(i) .eq. mod(i, numElms)) , "Assert MPElmID Fail")
+  !end do
 
   do i = 1,numCompsVel
     do j = 1,nverts 


### PR DESCRIPTION
This PR adds the `polympo_createMPs(...)` API, and associated tests, to create MPs from user provided data.  

The function `polympo_setMPCurElmID` was also removed.