### PR TITLE
Changing function names by adding "_f" in function names.(To show that the APIs are supporting fortran interface)

### DIFF
--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -8,20 +8,20 @@
 namespace{
   std::vector<MPMesh_ptr> p_mpmeshes;////store the p_mpmeshes that is legal
     
-  void checkMPMeshValid(MPMesh_ptr p_mpmesh){
+  void checkMPMeshValid_f(MPMesh_ptr p_mpmesh){
     auto p_mpmeshIter = std::find(p_mpmeshes.begin(),p_mpmeshes.end(),p_mpmesh);
     PMT_ALWAYS_ASSERT(p_mpmeshIter != p_mpmeshes.end());
   }
 }
 
-void polympo_initialize() {
+void polympo_initialize_f() {
   int isMPIInit;
   MPI_Initialized(&isMPIInit);
   PMT_ALWAYS_ASSERT(isMPIInit);
   Kokkos::initialize();
 }
 
-void polympo_finalize() {
+void polympo_finalize_f() {
   Kokkos::finalize();
 }
 
@@ -44,7 +44,7 @@ MPMesh_ptr polympo_createMPMesh(int testMeshOption, int testMPOption) {
   return p_mpMeshReturn;
 }
 
-void polympo_deleteMPMesh(MPMesh_ptr p_mpmesh) {
+void polympo_deleteMPMesh_f(MPMesh_ptr p_mpmesh) {
   //check mpMesh is valid
   auto p_mpmeshIter = std::find(p_mpmeshes.begin(),p_mpmeshes.end(),p_mpmesh);
   PMT_ALWAYS_ASSERT(p_mpmeshIter != p_mpmeshes.end());
@@ -52,7 +52,7 @@ void polympo_deleteMPMesh(MPMesh_ptr p_mpmesh) {
   delete (polyMPO::MPMesh*)p_mpmesh;
 }
 
-void polympo_setMPICommunicator(MPI_Fint fcomm){
+void polympo_setMPICommunicator_f(MPI_Fint fcomm){
     MPI_Comm comm = MPI_Comm_f2c(fcomm);
     int commSize;
     MPI_Comm_size(comm,&commSize);
@@ -169,7 +169,7 @@ void polympo_createMPs(MPMesh_ptr p_mpmesh,
   p_MPs->setElmIDoffset(offset);
 }
 
-void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh,
+void polympo_getMPCurElmID_f(MPMesh_ptr p_mpmesh,
                            int numMPs,
                            int* elmIDs){
   checkMPMeshValid(p_mpmesh);
@@ -191,7 +191,7 @@ void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh,
   Kokkos::deep_copy( arrayHost, mpCurElmIDCopy);
 }
 
-void polympo_getMPPositions(MPMesh_ptr p_mpmesh,
+void polympo_getMPPositions_f(MPMesh_ptr p_mpmesh,
                            int numComps,
                            int numMPs,
                            double* mpPositionsIn){ 
@@ -214,7 +214,7 @@ void polympo_getMPPositions(MPMesh_ptr p_mpmesh,
   Kokkos::deep_copy(arrayHost, mpPositionsCopy);
 }
 
-void polympo_setMPVel(MPMesh_ptr p_mpmesh, int size, double* array) {
+void polympo_setMPVel_f(MPMesh_ptr p_mpmesh, int size, double* array) {
   fprintf(stderr,"%s is no longer supported\n", __func__);
   PMT_ALWAYS_ASSERT(false);
   (void)p_mpmesh;// to silence the unused param warning
@@ -222,7 +222,7 @@ void polympo_setMPVel(MPMesh_ptr p_mpmesh, int size, double* array) {
   (void)array;
 }
 
-void polympo_getMPVel(MPMesh_ptr p_mpmesh, int size, double* array) {
+void polympo_getMPVel_f(MPMesh_ptr p_mpmesh, int size, double* array) {
   fprintf(stderr,"%s is no longer supported\n", __func__);
   PMT_ALWAYS_ASSERT(false);
   (void)p_mpmesh;// to silence the unused param warning
@@ -230,25 +230,25 @@ void polympo_getMPVel(MPMesh_ptr p_mpmesh, int size, double* array) {
   (void)array;
 }
 
-void polympo_startMeshFill(MPMesh_ptr p_mpmesh){
+void polympo_startMeshFill_f(MPMesh_ptr p_mpmesh){
   checkMPMeshValid(p_mpmesh);
   ((polyMPO::MPMesh*)p_mpmesh)->p_mesh->setMeshEdit(true);  
 }
 
-void polympo_endMeshFill(MPMesh_ptr p_mpmesh){
+void polympo_endMeshFill_f(MPMesh_ptr p_mpmesh){
   checkMPMeshValid(p_mpmesh);
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh; 
   PMT_ALWAYS_ASSERT(p_mesh->meshEditable());
   p_mesh->setMeshEdit(false);  
 }
 
-void polympo_checkMeshMaxSettings(MPMesh_ptr p_mpmesh, int maxEdges, int vertexDegree){
+void polympo_checkMeshMaxSettings_f(MPMesh_ptr p_mpmesh, int maxEdges, int vertexDegree){
   checkMPMeshValid(p_mpmesh);
   PMT_ALWAYS_ASSERT(maxEdges <= maxVtxsPerElm);
   PMT_ALWAYS_ASSERT(vertexDegree <=  maxElmsPerVtx);
 }
 
-void polympo_setMeshNumVtxs(MPMesh_ptr p_mpmesh, int numVtxs){
+void polympo_setMeshNumVtxs_f(MPMesh_ptr p_mpmesh, int numVtxs){
   checkMPMeshValid(p_mpmesh);
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;
   p_mesh->setNumVtxs(numVtxs);
@@ -262,7 +262,7 @@ int polympo_getMeshNumVtxs(MPMesh_ptr p_mpmesh) {
   return nVtxs;
 }
 
-void polympo_setMeshNumElms(MPMesh_ptr p_mpmesh, int numElms){
+void polympo_setMeshNumElms_f(MPMesh_ptr p_mpmesh, int numElms){
   checkMPMeshValid(p_mpmesh);
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;
 
@@ -281,31 +281,31 @@ int polympo_getMeshNumElms(MPMesh_ptr p_mpmesh) {
   return nElms;
 }
 
-void polympo_setMeshTypeGeneralPoly(MPMesh_ptr p_mpmesh){
+void polympo_setMeshTypeGeneralPoly_f(MPMesh_ptr p_mpmesh){
   //chech validity
   checkMPMeshValid(p_mpmesh);
   ((polyMPO::MPMesh*)p_mpmesh)->p_mesh->setMeshType(polyMPO::mesh_general_polygonal);
 }
 
-void polympo_setMeshTypeCVTPoly(MPMesh_ptr p_mpmesh){
+void polympo_setMeshTypeCVTPoly_f(MPMesh_ptr p_mpmesh){
   //chech validity
   checkMPMeshValid(p_mpmesh);
   ((polyMPO::MPMesh*)p_mpmesh)->p_mesh->setMeshType(polyMPO::mesh_CVT_polygonal);
 }
 
-void polympo_setMeshGeomTypePlanar(MPMesh_ptr p_mpmesh){
+void polympo_setMeshGeomTypePlanar_f(MPMesh_ptr p_mpmesh){
   //chech validity
   checkMPMeshValid(p_mpmesh);
   ((polyMPO::MPMesh*)p_mpmesh)->p_mesh->setGeomType(polyMPO::geom_planar_surf);
 }
 
-void polympo_setMeshGeomTypeSpherical(MPMesh_ptr p_mpmesh){
+void polympo_setMeshGeomTypeSpherical_f(MPMesh_ptr p_mpmesh){
   //chech validity
   checkMPMeshValid(p_mpmesh);
   ((polyMPO::MPMesh*)p_mpmesh)->p_mesh->setGeomType(polyMPO::geom_spherical_surf);
 }
 
-void polympo_setMeshSphereRadius(MPMesh_ptr p_mpmesh, double sphereRadius){
+void polympo_setMeshSphereRadius_f(MPMesh_ptr p_mpmesh, double sphereRadius){
   //chech validity
   checkMPMeshValid(p_mpmesh);
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;
@@ -313,7 +313,7 @@ void polympo_setMeshSphereRadius(MPMesh_ptr p_mpmesh, double sphereRadius){
   p_mesh->setSphereRadius(sphereRadius);
 }
 
-void polympo_setMeshNumEdgesPerElm(MPMesh_ptr p_mpmesh, int nCells, int* array){
+void polympo_setMeshNumEdgesPerElm_f(MPMesh_ptr p_mpmesh, int nCells, int* array){
   //chech vailidity
   checkMPMeshValid(p_mpmesh);
   kkIntViewHostU arrayHost(array,nCells);
@@ -333,7 +333,7 @@ void polympo_setMeshNumEdgesPerElm(MPMesh_ptr p_mpmesh, int nCells, int* array){
   });
 }
 
-void polympo_setMeshElm2VtxConn(MPMesh_ptr p_mpmesh, int maxEdges, int nCells, int* array){
+void polympo_setMeshElm2VtxConn_f(MPMesh_ptr p_mpmesh, int maxEdges, int nCells, int* array){
   //chech vailidity
   checkMPMeshValid(p_mpmesh);
   kkInt2dViewHostU arrayHost(array,maxEdges,nCells); 
@@ -354,7 +354,7 @@ void polympo_setMeshElm2VtxConn(MPMesh_ptr p_mpmesh, int maxEdges, int nCells, i
   });
 }
 
-void polympo_setMeshElm2ElmConn(MPMesh_ptr p_mpmesh, int maxEdges, int nCells, int* array){
+void polympo_setMeshElm2ElmConn_f(MPMesh_ptr p_mpmesh, int maxEdges, int nCells, int* array){
   //chech vailidity
   checkMPMeshValid(p_mpmesh);
   kkInt2dViewHostU arrayHost(array,maxEdges,nCells); //Fortran is column-major
@@ -375,7 +375,7 @@ void polympo_setMeshElm2ElmConn(MPMesh_ptr p_mpmesh, int maxEdges, int nCells, i
   });
 }
 
-void polympo_setMeshVtxCoords(MPMesh_ptr p_mpmesh, int nVertices, double* xArray, double* yArray, double* zArray){
+void polympo_setMeshVtxCoords_f(MPMesh_ptr p_mpmesh, int nVertices, double* xArray, double* yArray, double* zArray){
   //chech validity
   checkMPMeshValid(p_mpmesh);
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;
@@ -394,7 +394,7 @@ void polympo_setMeshVtxCoords(MPMesh_ptr p_mpmesh, int nVertices, double* xArray
   Kokkos::deep_copy(coordsArray, h_coordsArray);
 }
 
-void polympo_getMeshVtxCoords(MPMesh_ptr p_mpmesh, int nVertices, double* xArray, double* yArray, double* zArray){
+void polympo_getMeshVtxCoords_f(MPMesh_ptr p_mpmesh, int nVertices, double* xArray, double* yArray, double* zArray){
   //chech validity
   checkMPMeshValid(p_mpmesh);
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;
@@ -413,7 +413,7 @@ void polympo_getMeshVtxCoords(MPMesh_ptr p_mpmesh, int nVertices, double* xArray
   }
 }
 
-void polympo_setMeshOnSurfVeloIncr(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array) {
+void polympo_setMeshOnSurfVeloIncr_f(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array) {
   //check mpMesh is valid
   checkMPMeshValid(p_mpmesh);
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;
@@ -429,7 +429,7 @@ void polympo_setMeshOnSurfVeloIncr(MPMesh_ptr p_mpmesh, int nComps, int nVertice
   Kokkos::deep_copy(vtxField,arrayHost);
 }
 
-void polympo_getMeshOnSurfVeloIncr(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array) {
+void polympo_getMeshOnSurfVeloIncr_f(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array) {
   //check mpMesh is valid
   checkMPMeshValid(p_mpmesh);
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;
@@ -446,7 +446,7 @@ void polympo_getMeshOnSurfVeloIncr(MPMesh_ptr p_mpmesh, int nComps, int nVertice
   Kokkos::deep_copy(arrayHost, vtxField);
 }
 
-void polympo_setMeshOnSurfDispIncr(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array) {
+void polympo_setMeshOnSurfDispIncr_f(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array) {
   //check mpMesh is valid
   checkMPMeshValid(p_mpmesh);
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;
@@ -462,7 +462,7 @@ void polympo_setMeshOnSurfDispIncr(MPMesh_ptr p_mpmesh, int nComps, int nVertice
   Kokkos::deep_copy(vtxField,arrayHost);
 }
 
-void polympo_getMeshOnSurfDispIncr(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array) {
+void polympo_getMeshOnSurfDispIncr_f(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array) {
   //check mpMesh is valid
   checkMPMeshValid(p_mpmesh);
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -8,7 +8,7 @@
 namespace{
   std::vector<MPMesh_ptr> p_mpmeshes;////store the p_mpmeshes that is legal
     
-  void checkMPMeshValid_f(MPMesh_ptr p_mpmesh){
+  void checkMPMeshValid(MPMesh_ptr p_mpmesh){
     auto p_mpmeshIter = std::find(p_mpmeshes.begin(),p_mpmeshes.end(),p_mpmesh);
     PMT_ALWAYS_ASSERT(p_mpmeshIter != p_mpmeshes.end());
   }
@@ -25,7 +25,7 @@ void polympo_finalize_f() {
   Kokkos::finalize();
 }
 
-MPMesh_ptr polympo_createMPMesh(int testMeshOption, int testMPOption) {
+MPMesh_ptr polympo_createMPMesh_f(int testMeshOption, int testMPOption) {
   polyMPO::Mesh* p_mesh;
   if(testMeshOption){
     int replicateFactor = 1;
@@ -99,7 +99,7 @@ typedef Kokkos::View<
           Kokkos::MemoryTraits<Kokkos::Unmanaged>
         > kkIntViewHostU;//TODO:put it somewhere else (maybe)
 
-void polympo_createMPs(MPMesh_ptr p_mpmesh,
+void polympo_createMPs_f(MPMesh_ptr p_mpmesh,
                        int numElms,
                        int numMPs, // >= number of active MPs
                        int* mpsPerElm,
@@ -255,7 +255,7 @@ void polympo_setMeshNumVtxs_f(MPMesh_ptr p_mpmesh, int numVtxs){
   p_mesh->setMeshVtxBasedFieldSize(); 
 }
 
-int polympo_getMeshNumVtxs(MPMesh_ptr p_mpmesh) {
+int polympo_getMeshNumVtxs_f(MPMesh_ptr p_mpmesh) {
   checkMPMeshValid(p_mpmesh); //chech vailidity
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;
   int nVtxs = p_mesh->getNumVertices();
@@ -274,7 +274,7 @@ void polympo_setMeshNumElms_f(MPMesh_ptr p_mpmesh, int numElms){
   p_mesh->setElm2ElmConn(elm2Elm);
 }
 
-int polympo_getMeshNumElms(MPMesh_ptr p_mpmesh) {
+int polympo_getMeshNumElms_f(MPMesh_ptr p_mpmesh) {
   checkMPMeshValid(p_mpmesh); //chech vailidity
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;
   int nElms = p_mesh->getNumElements();

--- a/src/pmpo_c.h
+++ b/src/pmpo_c.h
@@ -8,49 +8,49 @@ extern "C" {
 typedef void* MPMesh_ptr;
 
 //initialize and finalize
-void polympo_initialize();
-void polympo_finalize();
+void polympo_initialize_f();
+void polympo_finalize_f();
 
 //create/delete MpMesh object
 MPMesh_ptr polympo_createMPMesh(int setMeshOption, int setMPOption);
-void polympo_deleteMPMesh(MPMesh_ptr p_mpmesh);
+void polympo_deleteMPMesh_f(MPMesh_ptr p_mpmesh);
 
 //set MPI communicator
-void polympo_setMPICommunicator(MPI_Fint fcomm);//TODO:is MPI_Fint best? or something else
+void polympo_setMPICommunicator_f(MPI_Fint fcomm);//TODO:is MPI_Fint best? or something else
 //TODO: add a function to get communicator
 
 //MP info
-void polympo_createMPs(MPMesh_ptr p_mpmesh, int numElms, int numMPs, int* mpsPerElm, int* mp2Elm, int* isMPActive);
-void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs);
-void polympo_getMPPositions(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);
+void polympo_createMPs_f(MPMesh_ptr p_mpmesh, int numElms, int numMPs, int* mpsPerElm, int* mp2Elm, int* isMPActive);
+void polympo_getMPCurElmID_f(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs);
+void polympo_getMPPositions_f(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);
 
 //MP slices
-void polympo_setMPVel(MPMesh_ptr p_mpmesh, int size, double* array);
-void polympo_getMPVel(MPMesh_ptr p_mpmesh, int size, double* array);
+void polympo_setMPVel_f(MPMesh_ptr p_mpmesh, int size, double* array);
+void polympo_getMPVel_f(MPMesh_ptr p_mpmesh, int size, double* array);
 
 //Mesh info
-void polympo_startMeshFill(MPMesh_ptr p_mpmesh);
-void polympo_endMeshFill(MPMesh_ptr p_mpmesh);
-void polympo_checkMeshMaxSettings(MPMesh_ptr p_mpmesh, int maxEdges, int vertexDegree);
-void polympo_setMeshTypeGeneralPoly(MPMesh_ptr p_mpmesh);
-void polympo_setMeshTypeCVTPoly(MPMesh_ptr p_mpmesh);
-void polympo_setMeshGeomTypePlanar(MPMesh_ptr p_mpmesh);
-void polympo_setMeshGeomTypeSpherical(MPMesh_ptr p_mpmesh);
-void polympo_setMeshSphereRadius(MPMesh_ptr p_mpmesh, double sphereRadius);
-void polympo_setMeshNumVtxs(MPMesh_ptr p_mpmesh, int numVtxs);
-int polympo_getMeshNumVtxs(MPMesh_ptr p_mpmesh);
-void polympo_setMeshNumElms(MPMesh_ptr p_mpmesh, int numElms);
-int polympo_getMeshNumElms(MPMesh_ptr p_mpmesh);
-void polympo_setMeshNumEdgesPerElm(MPMesh_ptr p_mpmesh, int nCells, int* array);
-void polympo_setMeshElm2VtxConn(MPMesh_ptr p_mpmesh, int maxEdges, int nCells, int* array);
-void polympo_setMeshElm2ElmConn(MPMesh_ptr p_mpmesh, int maxEdges, int nCells, int* array);
+void polympo_startMeshFill_f(MPMesh_ptr p_mpmesh);
+void polympo_endMeshFill_f(MPMesh_ptr p_mpmesh);
+void polympo_checkMeshMaxSettings_f(MPMesh_ptr p_mpmesh, int maxEdges, int vertexDegree);
+void polympo_setMeshTypeGeneralPoly_f(MPMesh_ptr p_mpmesh);
+void polympo_setMeshTypeCVTPoly_f(MPMesh_ptr p_mpmesh);
+void polympo_setMeshGeomTypePlanar_f(MPMesh_ptr p_mpmesh);
+void polympo_setMeshGeomTypeSpherical_f(MPMesh_ptr p_mpmesh);
+void polympo_setMeshSphereRadius_f(MPMesh_ptr p_mpmesh, double sphereRadius);
+void polympo_setMeshNumVtxs_f(MPMesh_ptr p_mpmesh, int numVtxs);
+int polympo_getMeshNumVtxs_f(MPMesh_ptr p_mpmesh);
+void polympo_setMeshNumElms_f(MPMesh_ptr p_mpmesh, int numElms);
+int polympo_getMeshNumElms_f(MPMesh_ptr p_mpmesh);
+void polympo_setMeshNumEdgesPerElm_f(MPMesh_ptr p_mpmesh, int nCells, int* array);
+void polympo_setMeshElm2VtxConn_f(MPMesh_ptr p_mpmesh, int maxEdges, int nCells, int* array);
+void polympo_setMeshElm2ElmConn_f(MPMesh_ptr p_mpmesh, int maxEdges, int nCells, int* array);
 
 //Mesh fields
-void polympo_setMeshVtxCoords(MPMesh_ptr p_mpmesh, int nVertices, double* xArray, double* yArray, double* zArray);
-void polympo_getMeshVtxCoords(MPMesh_ptr p_mpmesh, int nVertices, double* xArray, double* yArray, double* zArray);
-void polympo_setMeshOnSurfVeloIncr(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array);//vec2d
-void polympo_getMeshOnSurfVeloIncr(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array);//vec2d
-void polympo_setMeshOnSurfDispIncr(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array);//vec2d
-void polympo_getMeshOnSurfDispIncr(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array);//vec2d
+void polympo_setMeshVtxCoords_f(MPMesh_ptr p_mpmesh, int nVertices, double* xArray, double* yArray, double* zArray);
+void polympo_getMeshVtxCoords_f(MPMesh_ptr p_mpmesh, int nVertices, double* xArray, double* yArray, double* zArray);
+void polympo_setMeshOnSurfVeloIncr_f(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array);//vec2d
+void polympo_getMeshOnSurfVeloIncr_f(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array);//vec2d
+void polympo_setMeshOnSurfDispIncr_f(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array);//vec2d
+void polympo_getMeshOnSurfDispIncr_f(MPMesh_ptr p_mpmesh, int nComps, int nVertices, double* array);//vec2d
 }
 #endif

--- a/src/pmpo_c.h
+++ b/src/pmpo_c.h
@@ -12,7 +12,7 @@ void polympo_initialize_f();
 void polympo_finalize_f();
 
 //create/delete MpMesh object
-MPMesh_ptr polympo_createMPMesh(int setMeshOption, int setMPOption);
+MPMesh_ptr polympo_createMPMesh_f(int setMeshOption, int setMPOption);
 void polympo_deleteMPMesh_f(MPMesh_ptr p_mpmesh);
 
 //set MPI communicator

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -10,14 +10,14 @@ module polympo
   !> @brief initialize polympo, call this before any other polympo api
   !> @remark the user must initialize MPI prior to this call
   !---------------------------------------------------------------------------
-  subroutine polympo_initialize() bind(C, NAME='polympo_initialize')
+  subroutine polympo_initialize() bind(C, NAME='polympo_initialize_f')
     use :: iso_c_binding
   end subroutine
   !---------------------------------------------------------------------------
   !> @brief finalize polympo, no polympo apis may be called after this
   !> @remark the user must not finalize MPI until after this call
   !---------------------------------------------------------------------------
-  subroutine polympo_finalize() bind(C, NAME='polympo_finalize')
+  subroutine polympo_finalize() bind(C, NAME='polympo_finalize_f')
     use :: iso_c_binding
   end subroutine
   !---------------------------------------------------------------------------
@@ -28,7 +28,7 @@ module polympo
   !>                       <0 init a blank set of MPs
   !> @return polympo_createMPMesh(out) MPMesh object
   !---------------------------------------------------------------------------
-  function polympo_createMPMesh(setMeshOption, setMPOption) bind(C, NAME='polympo_createMPMesh')
+  function polympo_createMPMesh(setMeshOption, setMPOption) bind(C, NAME='polympo_createMPMesh_f')
     use :: iso_c_binding
     type(c_ptr) polympo_createMPMesh
     integer(c_int), value :: setMeshOption, setMPOption
@@ -37,7 +37,7 @@ module polympo
   !> @brief delete MPMesh object
   !> @param mpmesh(in/out) MPMesh object
   !---------------------------------------------------------------------------
-  subroutine polympo_deleteMPMesh(mpMesh) bind(C, NAME='polympo_deleteMPMesh')
+  subroutine polympo_deleteMPMesh(mpMesh) bind(C, NAME='polympo_deleteMPMesh_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
   end subroutine
@@ -46,7 +46,7 @@ module polympo
   !> @param comm(in) MPI communicator
   !---------------------------------------------------------------------------
   subroutine polympo_setMPICommunicator(comm) &
-             bind(C, NAME='polympo_setMPICommunicator')
+             bind(C, NAME='polympo_setMPICommunicator_f')
     use :: iso_c_binding
     integer(c_int), value :: comm    
   end subroutine
@@ -61,7 +61,7 @@ module polympo
   !> @param isMPActive(in) set to 1 if the MP is active, 0 otherwise
   !---------------------------------------------------------------------------
   subroutine polympo_createMPs(mpMesh, numElms, numMPs, mpsPerElm, mp2Elm, isMPActive) &
-             bind(C, NAME='polympo_createMPs')
+             bind(C, NAME='polympo_createMPs_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: numElms
@@ -77,7 +77,7 @@ module polympo
   !> @param array(in/out) output MP element ID 1D array (numMPs), allocated by user
   !---------------------------------------------------------------------------
   subroutine polympo_getMPCurElmID(mpMesh, numMPs, array) &
-             bind(C, NAME='polympo_getMPCurElmID')
+             bind(C, NAME='polympo_getMPCurElmID_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: numMPs
@@ -92,7 +92,7 @@ module polympo
   !>                      allocated by user
   !---------------------------------------------------------------------------
   subroutine polympo_getMPPositions(mpMesh, nComps, numMPs, array) &
-             bind(C, NAME='polympo_getMPPositions')
+             bind(C, NAME='polympo_getMPPositions_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nComps, numMPs
@@ -106,7 +106,7 @@ module polympo
   !> @param array(in) input MP velocity 1D array (numMPs*2)
   !---------------------------------------------------------------------------
   subroutine polympo_setMPVel(mpMesh, n, array) &
-             bind(C, NAME='polympo_setMPVel')
+             bind(C, NAME='polympo_setMPVel_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: n
@@ -120,7 +120,7 @@ module polympo
   !> @param array(in/out) output MP velocity 1D array (numMPs*2), allocated by user
   !---------------------------------------------------------------------------
   subroutine polympo_getMPVel(mpMesh, n, array) &
-             bind(C, NAME='polympo_getMPVel')
+             bind(C, NAME='polympo_getMPVel_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: n
@@ -133,7 +133,7 @@ module polympo
   !> @param mpMesh(in/out) the MPMesh is valid/created
   !---------------------------------------------------------------------------
   subroutine polympo_startMeshFill(mpMesh) &
-             bind(C, NAME='polympo_startMeshFill')
+             bind(C, NAME='polympo_startMeshFill_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
   end subroutine
@@ -143,7 +143,7 @@ module polympo
   !> @param mpMesh(in/out) the MPMesh is valid/created
   !---------------------------------------------------------------------------
   subroutine polympo_endMeshFill(mpMesh) &
-             bind(C, NAME='polympo_endMeshFill')
+             bind(C, NAME='polympo_endMeshFill_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
   end subroutine
@@ -154,7 +154,7 @@ module polympo
   !> @param vertexDegree(in) the max vertexDegree of a vertex 
   !---------------------------------------------------------------------------
   subroutine polympo_checkMeshMaxSettings(mpMesh,maxEdges,vertexDegree) &
-             bind(C, NAME='polympo_checkMeshMaxSettings')
+             bind(C, NAME='polympo_checkMeshMaxSettings_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: maxEdges, vertexDegree
@@ -165,7 +165,7 @@ module polympo
   !> @param mpMesh(in/out) mpMesh object 
   !---------------------------------------------------------------------------
   subroutine polympo_setMeshTypeGeneralPoly(mpMesh) &
-             bind(C, NAME='polympo_setMeshTypeGeneralPoly')
+             bind(C, NAME='polympo_setMeshTypeGeneralPoly_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
   end subroutine
@@ -175,7 +175,7 @@ module polympo
   !> @param mpMesh(in/out) mpMesh object 
   !---------------------------------------------------------------------------
   subroutine polympo_setMeshTypeCVTPoly(mpMesh) &
-             bind(C, NAME='polympo_setMeshTypeCVTPoly')
+             bind(C, NAME='polympo_setMeshTypeCVTPoly_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
   end subroutine
@@ -185,7 +185,7 @@ module polympo
   !> @param mpMesh(in/out) mpMesh object 
   !---------------------------------------------------------------------------
   subroutine polympo_setMeshGeomTypePlanar(mpMesh) &
-             bind(C, NAME='polympo_setMeshGeomTypePlanar')
+             bind(C, NAME='polympo_setMeshGeomTypePlanar_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
   end subroutine
@@ -195,7 +195,7 @@ module polympo
   !> @param mpMesh(in/out) mpMesh object 
   !---------------------------------------------------------------------------
   subroutine polympo_setMeshGeomTypeSpherical(mpMesh) &
-             bind(C, NAME='polympo_setMeshGeomTypeSpherical')
+             bind(C, NAME='polympo_setMeshGeomTypeSpherical_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
   end subroutine
@@ -205,7 +205,7 @@ module polympo
   !> @param mpMesh(in/out) mpMesh object 
   !---------------------------------------------------------------------------
   subroutine polympo_setMeshSphereRadius(mpMesh,sphereRadius) &
-             bind(C, NAME='polympo_setMeshSphereRadius')
+             bind(C, NAME='polympo_setMeshSphereRadius_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     real(c_double), value :: sphereRadius
@@ -217,7 +217,7 @@ module polympo
   !> @param numVtxs(in) the number of vertices need to set
   !---------------------------------------------------------------------------
   subroutine polympo_setMeshNumVtxs(mpMesh,numVtxs) &
-             bind(C, NAME='polympo_setMeshNumVtxs')
+             bind(C, NAME='polympo_setMeshNumVtxs_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: numVtxs
@@ -228,7 +228,7 @@ module polympo
   !> @param numVtxs(return)) the number of vertices
   !---------------------------------------------------------------------------
   function polympo_getMeshNumVtxs(mpMesh) result(numVtxs) &
-            bind(C, NAME = 'polympo_getMeshNumVtxs')
+            bind(C, NAME = 'polympo_getMeshNumVtxs_f')
     use :: iso_c_binding
     type(c_ptr), intent(in), value :: mpMesh
     integer(c_int) :: numVtxs
@@ -240,7 +240,7 @@ module polympo
   !> @param numElms(in) the number of elements
   !---------------------------------------------------------------------------
   subroutine polympo_setMeshNumElms(mpMesh,numElms) &
-             bind(C, NAME='polympo_setMeshNumElms')
+             bind(C, NAME='polympo_setMeshNumElms_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: numElms
@@ -251,7 +251,7 @@ module polympo
   !> @param numVtxs(return)) the number of elements
   !---------------------------------------------------------------------------
   function polympo_getMeshNumElms(mpMesh) result(numElms) &
-            bind(C, NAME = 'polympo_getMeshNumElms')
+            bind(C, NAME = 'polympo_getMeshNumElms_f')
     use :: iso_c_binding
     type(c_ptr), intent(in), value :: mpMesh
     integer(c_int) :: numElms
@@ -264,7 +264,7 @@ module polympo
   !> @param verticesOnCell(in) element to vertices connectivity 2D array 
   !---------------------------------------------------------------------------
   subroutine polympo_setMeshElm2VtxConn(mpMesh, maxEdges, nCells, verticesOnCell) &
-             bind(C, NAME='polympo_setMeshElm2VtxConn')
+             bind(C, NAME='polympo_setMeshElm2VtxConn_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: maxEdges, nCells
@@ -278,7 +278,7 @@ module polympo
   !> @param cellsOnCell(in) element to elements connectivity 2D array 
   !---------------------------------------------------------------------------
   subroutine polympo_setMeshElm2ElmConn(mpMesh, maxEdges, nCells, cellsOnCell) &
-             bind(C, NAME='polympo_setMeshElm2ElmConn')
+             bind(C, NAME='polympo_setMeshElm2ElmConn_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: maxEdges, nCells
@@ -292,7 +292,7 @@ module polympo
   !> @param nEdgesOnCell(in) number of edges per element
   !---------------------------------------------------------------------------
   subroutine polympo_setMeshNumEdgesPerElm(mpMesh, nCells, nEdgesOnCell) &
-             bind(C, NAME='polympo_setMeshNumEdgesPerElm')
+             bind(C, NAME='polympo_setMeshNumEdgesPerElm_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nCells
@@ -305,7 +305,7 @@ module polympo
   !> @param x/y/zArray(in) the 1D arrays of vertices coordinates
   !---------------------------------------------------------------------------
   subroutine polympo_setMeshVtxCoords(mpMesh, nVertices, xArray, yArray, zArray) &
-             bind(C, NAME='polympo_setMeshVtxCoords')
+             bind(C, NAME='polympo_setMeshVtxCoords_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nVertices
@@ -318,7 +318,7 @@ module polympo
   !> @param x/y/zArray(in/out) the 1D arrays of vertices coordinates
   !---------------------------------------------------------------------------
   subroutine polympo_getMeshVtxCoords(mpMesh, nVertices, xArray, yArray, zArray) &
-             bind(C, NAME='polympo_getMeshVtxCoords')
+             bind(C, NAME='polympo_getMeshVtxCoords_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nVertices
@@ -333,7 +333,7 @@ module polympo
   !> @param array(in) input mesh velocity 2D array (2,numVtx)
   !---------------------------------------------------------------------------
   subroutine polympo_setMeshOnSurfVeloIncr(mpMesh, nComps, nVertices, array) &
-             bind(C, NAME='polympo_setMeshOnSurfVeloIncr')
+             bind(C, NAME='polympo_setMeshOnSurfVeloIncr_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nComps, nVertices
@@ -349,7 +349,7 @@ module polympo
   !>        2D array (2,numVtx), allocated by user
   !---------------------------------------------------------------------------
   subroutine polympo_getMeshOnSurfVeloIncr(mpMesh, nComps, nVertices, array) &
-             bind(C, NAME='polympo_getMeshOnSurfVeloIncr')
+             bind(C, NAME='polympo_getMeshOnSurfVeloIncr_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nComps, nVertices
@@ -364,7 +364,7 @@ module polympo
   !> @param array(in) input mesh velocity 2D array (2,numVtx)
   !---------------------------------------------------------------------------
   subroutine polympo_setMeshOnSurfDispIncr(mpMesh, nComps, nVertices, array) &
-             bind(C, NAME='polympo_setMeshOnSurfDispIncr')
+             bind(C, NAME='polympo_setMeshOnSurfDispIncr_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nComps, nVertices
@@ -380,7 +380,7 @@ module polympo
   !>        2D array (2,numVtx), allocated by user
   !---------------------------------------------------------------------------
   subroutine polympo_getMeshOnSurfDispIncr(mpMesh, nComps, nVertices, array) &
-             bind(C, NAME='polympo_getMeshOnSurfDispIncr')
+             bind(C, NAME='polympo_getMeshOnSurfDispIncr_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nComps, nVertices


### PR DESCRIPTION
Made changes to pmpo_c.cpp, pmpo_c.h and pmpo_fortran.f90. I changed the function names for the functions that appear in all 3 files by adding "_f" in front of each function name to show that the APIs are supporting fortran interface. I built and tested the code and all test passed. Tested today right Steps to test the code:
```
source setupEnvironment.sh     
./doConfigPolyMpo-GPU.sh
./buildPolyMpo-GPU.sh
ctest --test-dir buildPolyMPO-GPU
```