### PR TITLE
support getting and setting the positions of material points

### DIFF
--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -224,7 +224,7 @@ void polympo_getMPPositions(MPMesh_ptr p_mpmesh,
   checkMPMeshValid(p_mpmesh);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
   PMT_ALWAYS_ASSERT(numComps == vec3d_nEntries);
-  PMT_ALWAYS_ASSERT(numMPs == p_MPs->getCount());
+  PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getCount());
 
   auto mpPositions = p_MPs->getData<polyMPO::MPF_Cur_Pos_XYZ>();
   auto mpAppID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -77,6 +77,13 @@ typedef Kokkos::View<
           Kokkos::DefaultHostExecutionSpace,
           Kokkos::MemoryTraits<Kokkos::Unmanaged>
         > kkVec2dViewHostU;//TODO:put it to mesh.hpp
+
+typedef Kokkos::View<
+          double*[vec3d_nEntries],
+          Kokkos::LayoutLeft,
+          Kokkos::DefaultHostExecutionSpace,
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>
+        > kkVec3dViewHostU;//TODO:put it to mesh.hpp
                          
 typedef Kokkos::View<
           double**,
@@ -203,7 +210,7 @@ void polympo_setMPPositions(MPMesh_ptr p_mpmesh,
 
   auto mpPositions = p_MPs->getData<polyMPO::MPF_Cur_Pos_XYZ>();
   auto mpAppID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();
-  kkDbl2dViewHostU mpPositionsIn_h(mpPositionsIn,numComps,numMPs);
+  kkVec3dViewHostU mpPositionsIn_h(mpPositionsIn,numMPs);
   Kokkos::View<double**> mpPositionsIn_d("mpPositionsDevice",vec3d_nEntries,numMPs);
   Kokkos::deep_copy(mpPositionsIn_d, mpPositionsIn_h);
   auto setPos = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
@@ -214,7 +221,6 @@ void polympo_setMPPositions(MPMesh_ptr p_mpmesh,
     }
   };
   p_MPs->parallel_for(setPos, "setMPPositions");
-  assert(cudaSuccess == cudaDeviceSynchronize());
 }
 
 void polympo_getMPPositions(MPMesh_ptr p_mpmesh,
@@ -228,7 +234,7 @@ void polympo_getMPPositions(MPMesh_ptr p_mpmesh,
 
   auto mpPositions = p_MPs->getData<polyMPO::MPF_Cur_Pos_XYZ>();
   auto mpAppID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();
-  kkDbl2dViewHostU arrayHost(mpPositionsIn,numComps,numMPs);
+  kkVec3dViewHostU arrayHost(mpPositionsIn,numMPs);
   Kokkos::View<double**> mpPositionsCopy("mpPositionsCopy",vec3d_nEntries,numMPs);
   auto getPos = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
     if(mask){

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -230,14 +230,14 @@ void polympo_getMPPositions(MPMesh_ptr p_mpmesh,
   auto mpAppID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();
   kkDbl2dViewHostU arrayHost(mpPositionsIn,numComps,numMPs);
   Kokkos::View<double**> mpPositionsCopy("mpPositionsCopy",vec3d_nEntries,numMPs);
-  auto setVel = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
+  auto getPos = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
     if(mask){
-        mpPositionsCopy(0,mpAppID(mp)) = mpPositions(mp,0);
-        mpPositionsCopy(1,mpAppID(mp)) = mpPositions(mp,1);
-        mpPositionsCopy(2,mpAppID(mp)) = mpPositions(mp,2);
+      mpPositionsCopy(0,mpAppID(mp)) = mpPositions(mp,0);
+      mpPositionsCopy(1,mpAppID(mp)) = mpPositions(mp,1);
+      mpPositionsCopy(2,mpAppID(mp)) = mpPositions(mp,2);
     }
   };
-  p_MPs->parallel_for(setVel, "getMPPositions");
+  p_MPs->parallel_for(getPos, "getMPPositions");
   Kokkos::deep_copy(arrayHost, mpPositionsCopy);
 }
 

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -202,6 +202,8 @@ void polympo_setMPPositions(MPMesh_ptr p_mpmesh,
                             int numComps,
                             int numMPs,
                             double* mpPositionsIn){
+  static int callCount = 0;
+  PMT_ALWAYS_ASSERT(callCount == 0);
   checkMPMeshValid(p_mpmesh);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
   PMT_ALWAYS_ASSERT(numComps == vec3d_nEntries);
@@ -221,6 +223,7 @@ void polympo_setMPPositions(MPMesh_ptr p_mpmesh,
     }
   };
   p_MPs->parallel_for(setPos, "setMPPositions");
+  callCount++;
 }
 
 void polympo_getMPPositions(MPMesh_ptr p_mpmesh,

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -192,9 +192,9 @@ void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh,
 }
 
 void polympo_setMPPositions(MPMesh_ptr p_mpmesh,
-                           int numComps,
-                           int numMPs,
-                           double* mpPositionsIn){
+                            int numComps,
+                            int numMPs,
+                            double* mpPositionsIn){
   checkMPMeshValid(p_mpmesh);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
   PMT_ALWAYS_ASSERT(numComps == vec3d_nEntries);
@@ -208,12 +208,13 @@ void polympo_setMPPositions(MPMesh_ptr p_mpmesh,
   Kokkos::deep_copy(mpPositionsIn_d, mpPositionsIn_h);
   auto setPos = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
     if(mask){
-      mpPositions(0,mp) = mpPositionsIn_d(mpAppID(mp),0);
-      mpPositions(1,mp) = mpPositionsIn_d(mpAppID(mp),1);
-      mpPositions(2,mp) = mpPositionsIn_d(mpAppID(mp),2);
+      mpPositions(mp,0) = mpPositionsIn_d(0, mpAppID(mp));
+      mpPositions(mp,1) = mpPositionsIn_d(1, mpAppID(mp));
+      mpPositions(mp,2) = mpPositionsIn_d(2, mpAppID(mp));
     }
   };
   p_MPs->parallel_for(setPos, "setMPPositions");
+  assert(cudaSuccess == cudaDeviceSynchronize());
 }
 
 void polympo_getMPPositions(MPMesh_ptr p_mpmesh,

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -79,13 +79,6 @@ typedef Kokkos::View<
         > kkVec2dViewHostU;//TODO:put it to mesh.hpp
 
 typedef Kokkos::View<
-          double*[vec3d_nEntries],
-          Kokkos::LayoutLeft,
-          Kokkos::DefaultHostExecutionSpace,
-          Kokkos::MemoryTraits<Kokkos::Unmanaged>
-        > kkVec3dViewHostU;//TODO:put it to mesh.hpp
-                         
-typedef Kokkos::View<
           double**,
           Kokkos::LayoutLeft,
           Kokkos::DefaultHostExecutionSpace,

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -219,7 +219,7 @@ void polympo_setMPPositions_f(MPMesh_ptr p_mpmesh,
   callCount++;
 }
 
-void polympo_getMPPositions(MPMesh_ptr p_mpmesh,
+void polympo_getMPPositions_f(MPMesh_ptr p_mpmesh,
                             int numComps,
                             int numMPs,
                             double* mpPositionsHost){

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -224,9 +224,9 @@ void polympo_setMPPositions(MPMesh_ptr p_mpmesh,
 }
 
 void polympo_getMPPositions(MPMesh_ptr p_mpmesh,
-                           int numComps,
-                           int numMPs,
-                           double* mpPositionsHost){
+                            int numComps,
+                            int numMPs,
+                            double* mpPositionsHost){
   checkMPMeshValid(p_mpmesh);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
   PMT_ALWAYS_ASSERT(numComps == vec3d_nEntries);

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -198,7 +198,8 @@ void polympo_setMPPositions(MPMesh_ptr p_mpmesh,
   checkMPMeshValid(p_mpmesh);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
   PMT_ALWAYS_ASSERT(numComps == vec3d_nEntries);
-  PMT_ALWAYS_ASSERT(numMPs == p_MPs->getCount());
+  PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getCount());
+  //PMT_ALWAYS_ASSERT(numMPs >= maxMpAppID); //add max reduction to creation
 
   auto mpPositions = p_MPs->getData<polyMPO::MPF_Cur_Pos_XYZ>();
   auto mpAppID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();
@@ -207,9 +208,9 @@ void polympo_setMPPositions(MPMesh_ptr p_mpmesh,
   Kokkos::deep_copy(mpPositionsIn_d, mpPositionsIn_h);
   auto setPos = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
     if(mask){
-        mpPositions(0,mpAppID(mp)) = mpPositionsIn_d(mp,0);
-        mpPositions(1,mpAppID(mp)) = mpPositionsIn_d(mp,1);
-        mpPositions(2,mpAppID(mp)) = mpPositionsIn_d(mp,2);
+      mpPositions(0,mp) = mpPositionsIn_d(mpAppID(mp),0);
+      mpPositions(1,mp) = mpPositionsIn_d(mpAppID(mp),1);
+      mpPositions(2,mp) = mpPositionsIn_d(mpAppID(mp),2);
     }
   };
   p_MPs->parallel_for(setPos, "setMPPositions");

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -191,7 +191,7 @@ void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh,
   Kokkos::deep_copy( arrayHost, mpCurElmIDCopy);
 }
 
-void polympo_setMPPositions(MPMesh_ptr p_mpmesh,
+void polympo_setMPPositions_f(MPMesh_ptr p_mpmesh,
                             int numComps,
                             int numMPs,
                             double* mpPositionsIn){

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -213,13 +213,13 @@ void polympo_setMPPositions(MPMesh_ptr p_mpmesh,
   auto mpPositions = p_MPs->getData<polyMPO::MPF_Cur_Pos_XYZ>();
   auto mpAppID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();
   kkVec3dViewHostU mpPositionsIn_h(mpPositionsIn,numMPs);
-  Kokkos::View<double**> mpPositionsIn_d("mpPositionsDevice",vec3d_nEntries,numMPs);
+  Kokkos::View<double*[vec3d_nEntries]> mpPositionsIn_d("mpPositionsDevice",numMPs);
   Kokkos::deep_copy(mpPositionsIn_d, mpPositionsIn_h);
   auto setPos = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
     if(mask){
-      mpPositions(mp,0) = mpPositionsIn_d(0, mpAppID(mp));
-      mpPositions(mp,1) = mpPositionsIn_d(1, mpAppID(mp));
-      mpPositions(mp,2) = mpPositionsIn_d(2, mpAppID(mp));
+      mpPositions(mp,0) = mpPositionsIn_d(mpAppID(mp),0);
+      mpPositions(mp,1) = mpPositionsIn_d(mpAppID(mp),1);
+      mpPositions(mp,2) = mpPositionsIn_d(mpAppID(mp),2);
     }
   };
   p_MPs->parallel_for(setPos, "setMPPositions");
@@ -239,12 +239,12 @@ void polympo_getMPPositions(MPMesh_ptr p_mpmesh,
   auto mpPositions = p_MPs->getData<polyMPO::MPF_Cur_Pos_XYZ>();
   auto mpAppID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();
   kkVec3dViewHostU arrayHost(mpPositionsHost,numMPs);
-  Kokkos::View<double**> mpPositionsCopy("mpPositionsCopy",vec3d_nEntries,numMPs);
+  Kokkos::View<double*[vec3d_nEntries]> mpPositionsCopy("mpPositionsCopy",numMPs);
   auto getPos = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
     if(mask){
-      mpPositionsCopy(0,mpAppID(mp)) = mpPositions(mp,0);
-      mpPositionsCopy(1,mpAppID(mp)) = mpPositions(mp,1);
-      mpPositionsCopy(2,mpAppID(mp)) = mpPositions(mp,2);
+      mpPositionsCopy(mpAppID(mp),0) = mpPositions(mp,0);
+      mpPositionsCopy(mpAppID(mp),1) = mpPositions(mp,1);
+      mpPositionsCopy(mpAppID(mp),2) = mpPositions(mp,2);
     }
   };
   p_MPs->parallel_for(getPos, "getMPPositions");

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -226,7 +226,7 @@ void polympo_setMPPositions(MPMesh_ptr p_mpmesh,
 void polympo_getMPPositions(MPMesh_ptr p_mpmesh,
                            int numComps,
                            int numMPs,
-                           double* mpPositionsIn){ 
+                           double* mpPositionsHost){
   checkMPMeshValid(p_mpmesh);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
   PMT_ALWAYS_ASSERT(numComps == vec3d_nEntries);
@@ -234,7 +234,7 @@ void polympo_getMPPositions(MPMesh_ptr p_mpmesh,
 
   auto mpPositions = p_MPs->getData<polyMPO::MPF_Cur_Pos_XYZ>();
   auto mpAppID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();
-  kkVec3dViewHostU arrayHost(mpPositionsIn,numMPs);
+  kkVec3dViewHostU arrayHost(mpPositionsHost,numMPs);
   Kokkos::View<double**> mpPositionsCopy("mpPositionsCopy",vec3d_nEntries,numMPs);
   auto getPos = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
     if(mask){

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -208,7 +208,7 @@ void polympo_setMPPositions(MPMesh_ptr p_mpmesh,
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
   PMT_ALWAYS_ASSERT(numComps == vec3d_nEntries);
   PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getCount());
-  //PMT_ALWAYS_ASSERT(numMPs >= maxMpAppID); //add max reduction to creation
+  PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getMaxAppID());
 
   auto mpPositions = p_MPs->getData<polyMPO::MPF_Cur_Pos_XYZ>();
   auto mpAppID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();
@@ -234,6 +234,7 @@ void polympo_getMPPositions(MPMesh_ptr p_mpmesh,
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
   PMT_ALWAYS_ASSERT(numComps == vec3d_nEntries);
   PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getCount());
+  PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getMaxAppID());
 
   auto mpPositions = p_MPs->getData<polyMPO::MPF_Cur_Pos_XYZ>();
   auto mpAppID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();

--- a/src/pmpo_c.h
+++ b/src/pmpo_c.h
@@ -25,7 +25,7 @@ void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs);
 
 //MP slices
 void polympo_getMPPositions_f(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);
-void polympo_setMPPositions(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);
+void polympo_setMPPositions_f(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);
 void polympo_setMPVel(MPMesh_ptr p_mpmesh, int size, double* array);
 void polympo_getMPVel(MPMesh_ptr p_mpmesh, int size, double* array);
 

--- a/src/pmpo_c.h
+++ b/src/pmpo_c.h
@@ -22,9 +22,10 @@ void polympo_setMPICommunicator(MPI_Fint fcomm);//TODO:is MPI_Fint best? or some
 //MP info
 void polympo_createMPs(MPMesh_ptr p_mpmesh, int numElms, int numMPs, int* mpsPerElm, int* mp2Elm, int* isMPActive);
 void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs);
-void polympo_getMPPositions(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);
 
 //MP slices
+void polympo_getMPPositions(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);
+void polympo_setMPPositions(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);
 void polympo_setMPVel(MPMesh_ptr p_mpmesh, int size, double* array);
 void polympo_getMPVel(MPMesh_ptr p_mpmesh, int size, double* array);
 

--- a/src/pmpo_c.h
+++ b/src/pmpo_c.h
@@ -24,7 +24,7 @@ void polympo_createMPs(MPMesh_ptr p_mpmesh, int numElms, int numMPs, int* mpsPer
 void polympo_getMPCurElmID(MPMesh_ptr p_mpmesh, int numMPs, int* elmIDs);
 
 //MP slices
-void polympo_getMPPositions(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);
+void polympo_getMPPositions_f(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);
 void polympo_setMPPositions(MPMesh_ptr p_mpmesh, int numComps, int numMPs, double* mpPositionsIn);
 void polympo_setMPVel(MPMesh_ptr p_mpmesh, int size, double* array);
 void polympo_getMPVel(MPMesh_ptr p_mpmesh, int size, double* array);

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -99,6 +99,21 @@ module polympo
     type(c_ptr), value :: array
   end subroutine
   !---------------------------------------------------------------------------
+  !> @brief set the MP positions array from a host array
+  !> @param mpmesh(in/out) MPMesh object
+  !> @param nComps(in) number of components, should always be 3
+  !> @param numMPs(in) number of the MPs
+  !> @param array(in) MP current position 2D array (3,numMPs), allocated by user on host
+  !---------------------------------------------------------------------------
+  subroutine polympo_setMPPositions(mpMesh, nComps, numMPs, array) &
+             bind(C, NAME='polympo_getMPPositions')
+    use :: iso_c_binding
+    type(c_ptr), value :: mpMesh
+    integer(c_int), value :: nComps, numMPs
+    type(c_ptr), value :: array
+  end subroutine
+
+  !---------------------------------------------------------------------------
   !> @brief set the velocity MP array from a host array
   !> @warning THIS IS NOT SUPPORTED YET 
   !> @param mpmesh(in/out) MPMesh object

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -92,7 +92,7 @@ module polympo
   !>                      allocated by user
   !---------------------------------------------------------------------------
   subroutine polympo_getMPPositions(mpMesh, nComps, numMPs, array) &
-             bind(C, NAME='polympo_getMPPositions')
+             bind(C, NAME='polympo_getMPPositions_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nComps, numMPs

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -106,7 +106,7 @@ module polympo
   !> @param array(in) MP current position 2D array (3,numMPs), allocated by user on host
   !---------------------------------------------------------------------------
   subroutine polympo_setMPPositions(mpMesh, nComps, numMPs, array) &
-             bind(C, NAME='polympo_setMPPositions')
+             bind(C, NAME='polympo_setMPPositions_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nComps, numMPs

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -106,7 +106,7 @@ module polympo
   !> @param array(in) MP current position 2D array (3,numMPs), allocated by user on host
   !---------------------------------------------------------------------------
   subroutine polympo_setMPPositions(mpMesh, nComps, numMPs, array) &
-             bind(C, NAME='polympo_getMPPositions')
+             bind(C, NAME='polympo_setMPPositions')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nComps, numMPs

--- a/src/pmpo_materialPoints.cpp
+++ b/src/pmpo_materialPoints.cpp
@@ -8,12 +8,14 @@ PS* createDPS(int numElms, int numMPs, DoubleVec3dView positions, IntView mpsPer
   auto mpPositions = ps::getMemberView<MaterialPointTypes, MPF_Cur_Pos_XYZ>(mpInfo);
   auto mpCurElmPos = ps::getMemberView<MaterialPointTypes, MPF_Cur_Elm_ID>(mpInfo);
   auto mpStatus = ps::getMemberView<MaterialPointTypes, MPF_Status>(mpInfo);
+  auto mpAppID_m = ps::getMemberView<MaterialPointTypes, MPF_MP_APP_ID>(mpInfo);
   Kokkos::parallel_for("setMPinfo", numMPs, KOKKOS_LAMBDA(int i) {
     mpPositions(i,0) = positions(i,0);
     mpPositions(i,1) = positions(i,1);
     mpPositions(i,2) = positions(i,2);
     mpCurElmPos(i) = mp2elm(i);
     mpStatus(i) = 1; 
+    mpAppID_m(i) = i;
   });
   Kokkos::TeamPolicy<Kokkos::DefaultExecutionSpace> policy(numElms,Kokkos::AUTO);
   auto dps = new DPS<MaterialPointTypes>(policy, numElms, numMPs, mpsPerElm, elmGids, mp2elm, mpInfo);

--- a/src/pmpo_materialPoints.cpp
+++ b/src/pmpo_materialPoints.cpp
@@ -38,4 +38,16 @@ PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntVie
   return dps;
 }
 
+int getMaxAppID(IntView mpAppID) {
+  int maxAppID = 0;
+  Kokkos::parallel_reduce("getMax" , mpAppID.size(),
+    KOKKOS_LAMBDA(const int i, int & valueToUpdate) {
+      if ( mpAppID(i) > valueToUpdate ) valueToUpdate = mpAppID(i) ;
+    },
+    Kokkos::Max<int>(maxAppID)
+  );
+  fprintf(stderr, "maxAppID %d\n", maxAppID);
+  return maxAppID;
+}
+
 }

--- a/src/pmpo_materialPoints.cpp
+++ b/src/pmpo_materialPoints.cpp
@@ -48,7 +48,6 @@ int getMaxAppID(IntView mpAppID) {
     },
     Kokkos::Max<int>(maxAppID)
   );
-  fprintf(stderr, "maxAppID %d\n", maxAppID);
   return maxAppID;
 }
 

--- a/src/pmpo_materialPoints.hpp
+++ b/src/pmpo_materialPoints.hpp
@@ -95,7 +95,7 @@ typedef ps::ParticleStructure<MaterialPointTypes> PS;
 
 
 PS* createDPS(int numElms, int numMPs, DoubleVec3dView positions, IntView mpsPerElm, IntView mp2elm);
-PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView isMPActive);
+PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView mpAppID);
 
 class MaterialPoints {
   private:
@@ -107,8 +107,8 @@ class MaterialPoints {
     MaterialPoints(int numElms, int numMPs, DoubleVec3dView positions, IntView mpsPerElm, IntView mp2elm) {
       MPs = createDPS(numElms, numMPs, positions, mpsPerElm, mp2elm);
     };
-    MaterialPoints(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView isMPActive) {
-      MPs = createDPS(numElms, numMPs, mpsPerElm, mp2elm, isMPActive);
+    MaterialPoints(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView mpAppID) {
+      MPs = createDPS(numElms, numMPs, mpsPerElm, mp2elm, mpAppID);
     };
     ~MaterialPoints() {
       if(MPs != nullptr)

--- a/src/pmpo_materialPoints.hpp
+++ b/src/pmpo_materialPoints.hpp
@@ -108,6 +108,7 @@ class MaterialPoints {
     MaterialPoints() : MPs(nullptr) {};
     MaterialPoints(int numElms, int numMPs, DoubleVec3dView positions, IntView mpsPerElm, IntView mp2elm) {
       MPs = createDPS(numElms, numMPs, positions, mpsPerElm, mp2elm);
+      maxAppID = numMPs; //this ctor does not support inactive MPs
     };
     MaterialPoints(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView mpAppID) {
       MPs = createDPS(numElms, numMPs, mpsPerElm, mp2elm, mpAppID);
@@ -183,7 +184,7 @@ class MaterialPoints {
       return elmIDoffset;
     }
     int getMaxAppID() {
-      PMT_ALWAYS_ASSERT(maxAppID != -1);
+      PMT_ALWAYS_ASSERT(maxAppID != -1); //fixme - not all tests set this
       return maxAppID;
     }
 

--- a/src/pmpo_materialPoints.hpp
+++ b/src/pmpo_materialPoints.hpp
@@ -111,7 +111,7 @@ class MaterialPoints {
     };
     MaterialPoints(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView mpAppID) {
       MPs = createDPS(numElms, numMPs, mpsPerElm, mp2elm, mpAppID);
-      maxAppID = getMaxAppID(mpAppID);
+      maxAppID = polyMPO::getMaxAppID(mpAppID);
     };
     ~MaterialPoints() {
       if(MPs != nullptr)
@@ -181,6 +181,10 @@ class MaterialPoints {
     int getElmIDoffset() {
       PMT_ALWAYS_ASSERT(elmIDoffset == 0 || elmIDoffset == 1);
       return elmIDoffset;
+    }
+    int getMaxAppID() {
+      PMT_ALWAYS_ASSERT(maxAppID != -1);
+      return maxAppID;
     }
 
 //MUTATOR  

--- a/src/pmpo_materialPoints.hpp
+++ b/src/pmpo_materialPoints.hpp
@@ -96,11 +96,13 @@ typedef ps::ParticleStructure<MaterialPointTypes> PS;
 
 PS* createDPS(int numElms, int numMPs, DoubleVec3dView positions, IntView mpsPerElm, IntView mp2elm);
 PS* createDPS(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView mpAppID);
+int getMaxAppID(IntView mpAppID);
 
 class MaterialPoints {
   private:
     PS* MPs;
     int elmIDoffset = -1;
+    int maxAppID = -1;
 
   public:
     MaterialPoints() : MPs(nullptr) {};
@@ -109,6 +111,7 @@ class MaterialPoints {
     };
     MaterialPoints(int numElms, int numMPs, IntView mpsPerElm, IntView mp2elm, IntView mpAppID) {
       MPs = createDPS(numElms, numMPs, mpsPerElm, mp2elm, mpAppID);
+      maxAppID = getMaxAppID(mpAppID);
     };
     ~MaterialPoints() {
       if(MPs != nullptr)

--- a/src/pmpo_materialPoints.hpp
+++ b/src/pmpo_materialPoints.hpp
@@ -184,7 +184,7 @@ class MaterialPoints {
       return elmIDoffset;
     }
     int getMaxAppID() {
-      PMT_ALWAYS_ASSERT(maxAppID != -1); //fixme - not all tests set this
+      PMT_ALWAYS_ASSERT(maxAppID != -1);
       return maxAppID;
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,7 @@ endfunction()
 
 pmpo_add_exe(testWachspress testWachspress.cpp)
 pmpo_add_exe(unitTest unitTest.cpp)
+pmpo_add_exe(cpu2gpu testCpuToGpuToCpuXfer.cpp)
 pmpo_add_exe(mpUnitTest mpUnitTest.cpp)
 pmpo_add_exe(testReconstruction testReconstruction.cpp)
 pmpo_add_exe(testTracking testTracking.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,7 +43,6 @@ endfunction()
 
 pmpo_add_exe(testWachspress testWachspress.cpp)
 pmpo_add_exe(unitTest unitTest.cpp)
-pmpo_add_exe(cpu2gpu testCpuToGpuToCpuXfer.cpp)
 pmpo_add_exe(mpUnitTest mpUnitTest.cpp)
 pmpo_add_exe(testReconstruction testReconstruction.cpp)
 pmpo_add_exe(testTracking testTracking.cpp)

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -47,6 +47,7 @@ subroutine loadMPASMesh(mpMesh, filename)
     integer :: maxEdges, vertexDegree, nCells, nVertices
     integer, parameter :: nDims = 3
     integer, parameter :: MP_ACTIVE = 1
+    integer, parameter :: MP_INACTIVE = 0
     integer :: numMPs
     real(kind=MPAS_RKIND) :: ptOne = 0.100000000000000000
     real(kind=MPAS_RKIND) :: sphereRadius
@@ -95,8 +96,8 @@ subroutine loadMPASMesh(mpMesh, filename)
     allocate(mp2Elm(numMPs))
     allocate(isMPActive(numMPs))
     
-    isMPActive = 1 !no inactive MPs and some changed below
-    isMPActive(4) = 0 !first/1-st MP is indexed 1 and 4-th MP is inactive
+    isMPActive = MP_ACTIVE !no inactive MPs and some changed below
+    isMPActive(4) = MP_INACTIVE !first/1-st MP is indexed 1 and 4-th MP is inactive
    
     mpsPerElm = 1 !all elements have 1 MP and some changed below
     mpsPerElm(1) = 0 !1st element has 0 MPs

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -46,7 +46,7 @@ subroutine loadMPASMesh(mpMesh, filename)
     integer :: i
     integer :: maxEdges, vertexDegree, nCells, nVertices
     integer, parameter :: nDims = 3
-    integer, parameter :: MP_ACTIVE = 3
+    integer, parameter :: MP_ACTIVE = 1
     integer :: numMPs
     real(kind=MPAS_RKIND) :: ptOne = 0.100000000000000000
     real(kind=MPAS_RKIND) :: sphereRadius

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -8,6 +8,8 @@ subroutine assert(condition,message)
   endif
 end subroutine
 
+
+
 module readMPAS
     use :: polympo
     use iso_c_binding
@@ -15,6 +17,20 @@ module readMPAS
     integer, parameter :: MPAS_RKIND = selected_real_kind(12)
     
 contains
+
+function epsilonDiff(a,b) result(isSame)
+  implicit none
+  real(kind=MPAS_RKIND) :: a,b,delta
+  parameter (delta=1.0e-8)
+  logical :: isSame
+  !delta=1.0e-8
+  if (abs(a-b) < delta) then
+    isSame = .true.
+  else
+    isSame = .false.
+  endif
+end function
+
 !---------------------------------------------------------------------------
 !> @brief get the MP positions array from a polympo array
 !> @param mpmesh(in/out) MPMesh object to fill, allocated by users
@@ -32,6 +48,7 @@ subroutine loadMPASMesh(mpMesh, filename)
     integer :: maxEdges, vertexDegree, nCells, nVertices
     integer :: nDims !FIXME - parameter???
     integer :: numMPs
+    real(kind=MPAS_RKIND) :: ptOne = 0.1
     real(kind=MPAS_RKIND) :: sphereRadius
     integer, dimension(:), pointer :: nEdgesOnCell
     real(kind=MPAS_RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
@@ -112,9 +129,9 @@ subroutine loadMPASMesh(mpMesh, filename)
     call polympo_getMPPositions(mpMesh,nDims,numMPs,c_loc(mpPosition))
     do i = 1,numMPs
       if(isMPActive(i) .eq. 1) then
-        call assert(mpPosition(1,i) .eq. i+0.1, "x position of MP does not match")
-        call assert(mpPosition(2,i) .eq. numMPs+i+0.1, "y position of MP does not match")
-        call assert(mpPosition(3,i) .eq. (2*numMPs)+i+0.1, "z position of MP does not match")
+        call assert(epsilonDiff(mpPosition(1,i),i+ptOne), "x position of MP does not match")
+        call assert(epsilonDiff(mpPosition(2,i),numMPs+i+ptOne), "y position of MP does not match")
+        call assert(epsilonDiff(mpPosition(3,i),(2*numMPs)+i+ptOne), "z position of MP does not match")
       endif
     end do
     

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -108,6 +108,7 @@ subroutine loadMPASMesh(mpMesh, filename)
     end do
 
     call polympo_setMPPositions(mpMesh,nDims,numMPs,c_loc(mpPosition))
+    mpPosition = 0
     call polympo_getMPPositions(mpMesh,nDims,numMPs,c_loc(mpPosition))
     do i = 1,numMPs
       if(isMPActive(i) .eq. 1) then

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -110,9 +110,11 @@ subroutine loadMPASMesh(mpMesh, filename)
     call polympo_setMPPositions(mpMesh,nDims,numMPs,c_loc(mpPosition))
     call polympo_getMPPositions(mpMesh,nDims,numMPs,c_loc(mpPosition))
     do i = 1,numMPs
-      call assert(mpPosition(1,i) .eq. i+0.1, "x position of MP does not match")
-      call assert(mpPosition(2,i) .eq. numMPs+i+0.1, "y position of MP does not match")
-      call assert(mpPosition(3,i) .eq. (2*numMPs)+i+0.1, "z position of MP does not match")
+      if(isMPActive(i) .eq. 1) then
+        call assert(mpPosition(1,i) .eq. i+0.1, "x position of MP does not match")
+        call assert(mpPosition(2,i) .eq. numMPs+i+0.1, "y position of MP does not match")
+        call assert(mpPosition(3,i) .eq. (2*numMPs)+i+0.1, "z position of MP does not match")
+      endif
     end do
     
     mp2Elm = -99 !override values and then use get function below

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -23,7 +23,6 @@ function epsilonDiff(a,b) result(isSame)
   real(kind=MPAS_RKIND) :: a,b,delta
   parameter (delta=1.0e-8)
   logical :: isSame
-  !delta=1.0e-8
   if (abs(a-b) < delta) then
     isSame = .true.
   else
@@ -47,6 +46,7 @@ subroutine loadMPASMesh(mpMesh, filename)
     integer :: i
     integer :: maxEdges, vertexDegree, nCells, nVertices
     integer, parameter :: nDims = 3
+    integer, parameter :: MP_ACTIVE = 3
     integer :: numMPs
     real(kind=MPAS_RKIND) :: ptOne = 0.100000000000000000
     real(kind=MPAS_RKIND) :: sphereRadius
@@ -126,7 +126,7 @@ subroutine loadMPASMesh(mpMesh, filename)
     mpPosition = 42
     call polympo_getMPPositions(mpMesh,nDims,numMPs,c_loc(mpPosition))
     do i = 1,numMPs
-      if(isMPActive(i) .eq. 1) then
+      if(isMPActive(i) .eq. MP_ACTIVE) then
         call assert(epsilonDiff(mpPosition(1,i),i+ptOne), "x position of MP does not match")
         call assert(epsilonDiff(mpPosition(2,i),numMPs+i+ptOne), "y position of MP does not match")
         call assert(epsilonDiff(mpPosition(3,i),(2*numMPs)+i+ptOne), "z position of MP does not match")

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -48,7 +48,7 @@ subroutine loadMPASMesh(mpMesh, filename)
     integer :: maxEdges, vertexDegree, nCells, nVertices
     integer :: nDims !FIXME - parameter???
     integer :: numMPs
-    real(kind=MPAS_RKIND) :: ptOne = 0.1
+    real(kind=MPAS_RKIND) :: ptOne = 0.100000000000000000
     real(kind=MPAS_RKIND) :: sphereRadius
     integer, dimension(:), pointer :: nEdgesOnCell
     real(kind=MPAS_RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
@@ -119,19 +119,23 @@ subroutine loadMPASMesh(mpMesh, filename)
     !set mp positions
     allocate(mpPosition(nDims,numMPs))
     do i = 1,numMPs
-      mpPosition(1,i) = i+0.1
-      mpPosition(2,i) = numMPs+i+0.1
-      mpPosition(3,i) = (2*numMPs)+i+0.1
+      mpPosition(1,i) = i+ptOne
+      mpPosition(2,i) = numMPs+i+ptOne
+      mpPosition(3,i) = (2*numMPs)+i+ptOne
     end do
 
     call polympo_setMPPositions(mpMesh,nDims,numMPs,c_loc(mpPosition))
-    mpPosition = 0
+    mpPosition = 42
     call polympo_getMPPositions(mpMesh,nDims,numMPs,c_loc(mpPosition))
     do i = 1,numMPs
       if(isMPActive(i) .eq. 1) then
+        write(*,*) 'i', i, 'mpPos', mpPosition(1,i), 'expected', i+ptOne
+        if(.not. epsilonDiff(mpPosition(1,i),i+ptOne)) then
+          write(*,*) 'i', i, 'does not match'
+        endif
         call assert(epsilonDiff(mpPosition(1,i),i+ptOne), "x position of MP does not match")
-        call assert(epsilonDiff(mpPosition(2,i),numMPs+i+ptOne), "y position of MP does not match")
-        call assert(epsilonDiff(mpPosition(3,i),(2*numMPs)+i+ptOne), "z position of MP does not match")
+        !call assert(epsilonDiff(mpPosition(2,i),numMPs+i+ptOne), "y position of MP does not match")
+        !call assert(epsilonDiff(mpPosition(3,i),(2*numMPs)+i+ptOne), "z position of MP does not match")
       endif
     end do
     

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -102,9 +102,9 @@ subroutine loadMPASMesh(mpMesh, filename)
     !set mp positions
     allocate(mpPosition(nDims,numMPs))
     do i = 1,numMPs
-      mpPosition(0,i) = i+0.1
-      mpPosition(1,i) = numMPs+i+0.1
-      mpPosition(2,i) = (2*numMPs)+i+0.1
+      mpPosition(1,i) = i+0.1
+      mpPosition(2,i) = numMPs+i+0.1
+      mpPosition(3,i) = (2*numMPs)+i+0.1
     end do
 
     call polympo_setMPPositions(mpMesh,nDims,numMPs,c_loc(mpPosition))
@@ -120,6 +120,7 @@ subroutine loadMPASMesh(mpMesh, filename)
     end do
     !test end
 
+    deallocate(mpPosition)
     deallocate(mpsPerElm)
     deallocate(mp2Elm)
     deallocate(isMPActive)

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -108,6 +108,12 @@ subroutine loadMPASMesh(mpMesh, filename)
     end do
 
     call polympo_setMPPositions(mpMesh,nDims,numMPs,c_loc(mpPosition))
+    call polympo_getMPPositions(mpMesh,nDims,numMPs,c_loc(mpPosition))
+    do i = 1,numMPs
+      call assert(mpPosition(1,i) .eq. i+0.1, "x position of MP does not match")
+      call assert(mpPosition(2,i) .eq. numMPs+i+0.1, "y position of MP does not match")
+      call assert(mpPosition(3,i) .eq. (2*numMPs)+i+0.1, "z position of MP does not match")
+    end do
     
     mp2Elm = -99 !override values and then use get function below
     call polympo_getMPCurElmID(mpMesh,numMPs,c_loc(mp2Elm))

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -30,12 +30,16 @@ subroutine loadMPASMesh(mpMesh, filename)
     character (len=64) :: onSphere, stringYes = "YES"
     integer :: i
     integer :: maxEdges, vertexDegree, nCells, nVertices
+    integer :: nDims !FIXME - parameter???
     integer :: numMPs
     real(kind=MPAS_RKIND) :: sphereRadius
     integer, dimension(:), pointer :: nEdgesOnCell
     real(kind=MPAS_RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
     integer, dimension(:,:), pointer :: verticesOnCell, cellsOnCell
     integer, dimension(:), pointer :: mpsPerElm, mp2Elm, isMPActive
+    real(kind=MPAS_RKIND), dimension(:,:), pointer :: mpPosition
+
+    nDims = 3
     
     call readMPASMesh(trim(filename), maxEdges, vertexDegree, &
                               nCells, nVertices, nEdgesOnCell, &
@@ -94,6 +98,16 @@ subroutine loadMPASMesh(mpMesh, filename)
                       !i=numMPs leads to mp2Elm(numMPs=nCells+2)=numMPs-2=nCells
     end do
     call polympo_createMPs(mpMesh,nCells,numMPs,c_loc(mpsPerElm),c_loc(mp2Elm),c_loc(isMPActive))
+
+    !set mp positions
+    allocate(mpPosition(nDims,numMPs))
+    do i = 1,numMPs
+      mpPosition(0,i) = i+0.1
+      mpPosition(1,i) = numMPs+i+0.1
+      mpPosition(2,i) = (2*numMPs)+i+0.1
+    end do
+
+    call polympo_setMPPositions(mpMesh,nDims,numMPs,c_loc(mpPosition))
     
     mp2Elm = -99 !override values and then use get function below
     call polympo_getMPCurElmID(mpMesh,numMPs,c_loc(mp2Elm))

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -46,7 +46,7 @@ subroutine loadMPASMesh(mpMesh, filename)
     character (len=64) :: onSphere, stringYes = "YES"
     integer :: i
     integer :: maxEdges, vertexDegree, nCells, nVertices
-    integer :: nDims !FIXME - parameter???
+    integer, parameter :: nDims = 3
     integer :: numMPs
     real(kind=MPAS_RKIND) :: ptOne = 0.100000000000000000
     real(kind=MPAS_RKIND) :: sphereRadius
@@ -56,8 +56,6 @@ subroutine loadMPASMesh(mpMesh, filename)
     integer, dimension(:), pointer :: mpsPerElm, mp2Elm, isMPActive
     real(kind=MPAS_RKIND), dimension(:,:), pointer :: mpPosition
 
-    nDims = 3
-    
     call readMPASMesh(trim(filename), maxEdges, vertexDegree, &
                               nCells, nVertices, nEdgesOnCell, &
                               onSphere, sphereRadius, &

--- a/test/readMPAS.f90
+++ b/test/readMPAS.f90
@@ -129,13 +129,9 @@ subroutine loadMPASMesh(mpMesh, filename)
     call polympo_getMPPositions(mpMesh,nDims,numMPs,c_loc(mpPosition))
     do i = 1,numMPs
       if(isMPActive(i) .eq. 1) then
-        write(*,*) 'i', i, 'mpPos', mpPosition(1,i), 'expected', i+ptOne
-        if(.not. epsilonDiff(mpPosition(1,i),i+ptOne)) then
-          write(*,*) 'i', i, 'does not match'
-        endif
         call assert(epsilonDiff(mpPosition(1,i),i+ptOne), "x position of MP does not match")
-        !call assert(epsilonDiff(mpPosition(2,i),numMPs+i+ptOne), "y position of MP does not match")
-        !call assert(epsilonDiff(mpPosition(3,i),(2*numMPs)+i+ptOne), "z position of MP does not match")
+        call assert(epsilonDiff(mpPosition(2,i),numMPs+i+ptOne), "y position of MP does not match")
+        call assert(epsilonDiff(mpPosition(3,i),(2*numMPs)+i+ptOne), "z position of MP does not match")
       endif
     end do
     


### PR DESCRIPTION
This PR adds the `polympo_setMPPositions` and refactors the `polympo_getMPPositions` APIs that support passing host arrays with material point positions to the GPU structures maintained by pumipic.

All `ctest`s pass on `cranium`.

Note, issue https://github.com/SCOREC/polyMPO/issues/21 applies to the code used in these APIs as 2d arrays are being passed between the host to device.