### PR TITLE
Revert set/get dispIncr back

### DIFF
--- a/src/pmpo_MPMesh.cpp
+++ b/src/pmpo_MPMesh.cpp
@@ -90,8 +90,8 @@ void MPMesh::CVTTrackingElmCenterBased(const int printVTPIndex){
       printVTP_mesh(printVTPIndex);
     }
 
-    Vec3dView elmCenter("elmentCenter",numElms);
-    auto calcCenter = PS_LAMBDA(const int& elm, const int&, const int&){
+    Vec3dView elmCenter("elementCenter",numElms);
+    Kokkos::parallel_for("calcElementCenter", numElms, KOKKOS_LAMBDA(const int elm){  
         int numVtx = elm2VtxConn(elm,0);
         double sum_x = 0.0, sum_y = 0.0, sum_z = 0.0;
         for(int i=1; i<= numVtx; i++){
@@ -102,7 +102,7 @@ void MPMesh::CVTTrackingElmCenterBased(const int printVTPIndex){
         elmCenter(elm)[0] = sum_x/numVtx;
         elmCenter(elm)[1] = sum_y/numVtx;
         elmCenter(elm)[2] = sum_z/numVtx;
-    };
+    });
 
     Vec3dView history("positionHistory",numMPs);
     Vec3dView resultLeft("positionResult",numMPs);


### PR DESCRIPTION
Revert the `polympo_getMeshOnSurfDispIncr_f` and `polympo_setMeshOnSurfDispIncr_f` back using kokkos parallel for loop.

solving issue #44 , vtp file looks good now:
![image](https://github.com/SCOREC/polyMPO/assets/91505581/e80f1c64-2e02-4131-b9a2-0b4e4cd4ae3f)
