### PR TITLE
Change MPVelo APIs to 1D u/v velocity arrays

### DIFF
--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -334,7 +334,7 @@ void polympo_getMPRotLatLon_f(MPMesh_ptr p_mpmesh,
   Kokkos::deep_copy(arrayHost, mpRotLatLonCopy);
 }
 
-void polympo_setMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, const double* mpVelIn) {
+void polympo_setMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, const double* uVelIn, const double* vVelIn) {
   checkMPMeshValid(p_mpmesh);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
   PMT_ALWAYS_ASSERT(numComps == vec2d_nEntries);
@@ -343,19 +343,22 @@ void polympo_setMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMP
 
   auto mpVel = p_MPs->getData<polyMPO::MPF_Vel>();
   auto mpAppID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();
-  kkViewHostU<const double**> mpVelIn_h(mpVelIn,numComps,numMPs);
-  Kokkos::View<double**> mpVelIn_d("mpVelDevice",vec2d_nEntries,numMPs);
-  Kokkos::deep_copy(mpVelIn_d, mpVelIn_h);
+  kkViewHostU<const double*> uVelIn_h(uVelIn,numMPs);
+  Kokkos::View<double*> uVelIn_d("mpUCompVelDevice",numMPs);
+  Kokkos::deep_copy(uVelIn_d, uVelIn_h);
+  kkViewHostU<const double*> vVelIn_h(vVelIn,numMPs);
+  Kokkos::View<double*> vVelIn_d("mpVCompVelDevice",numMPs);
+  Kokkos::deep_copy(vVelIn_d, vVelIn_h);
   auto setMPVel = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
     if(mask){
-      mpVel(mp,0) = mpVelIn_d(0, mpAppID(mp));
-      mpVel(mp,1) = mpVelIn_d(1, mpAppID(mp));
+      mpVel(mp,0) = uVelIn_d(mpAppID(mp));
+      mpVel(mp,1) = vVelIn_d(mpAppID(mp));
     }
   };
   p_MPs->parallel_for(setMPVel, "setMPVel");
 }
 
-void polympo_getMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, double* mpVelHost) {
+void polympo_getMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, double* uVelHost, double* vVelHost) {
   checkMPMeshValid(p_mpmesh);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
   PMT_ALWAYS_ASSERT(numComps == vec2d_nEntries);
@@ -364,16 +367,19 @@ void polympo_getMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMP
 
   auto mpVel = p_MPs->getData<polyMPO::MPF_Vel>();
   auto mpAppID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();
-  Kokkos::View<double**> mpVelCopy("mpVelCopy",vec2d_nEntries,numMPs);
+  Kokkos::View<double*> uVelCopy("uVelCopy",numMPs);
+  Kokkos::View<double*> vVelCopy("vVelCopy",numMPs);
   auto getMPVel = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
     if(mask){
-      mpVelCopy(0,mpAppID(mp)) = mpVel(mp,0);
-      mpVelCopy(1,mpAppID(mp)) = mpVel(mp,1);
+      uVelCopy(mpAppID(mp)) = mpVel(mp,0);
+      vVelCopy(mpAppID(mp)) = mpVel(mp,1);
     }
   };
   p_MPs->parallel_for(getMPVel, "getMPVel");
-  kkDbl2dViewHostU arrayHost(mpVelHost,numComps,numMPs);
-  Kokkos::deep_copy(arrayHost, mpVelCopy);
+  kkDblViewHostU arrayHost_uVel(uVelHost,numMPs);
+  kkDblViewHostU arrayHost_vVel(vVelHost,numMPs);
+  Kokkos::deep_copy(arrayHost_uVel, uVelCopy);
+  Kokkos::deep_copy(arrayHost_vVel, vVelCopy);
 }
 
 void polympo_startMeshFill_f(MPMesh_ptr p_mpmesh){

--- a/src/pmpo_c.h
+++ b/src/pmpo_c.h
@@ -31,8 +31,8 @@ void polympo_setMPPositions_f(MPMesh_ptr p_mpmesh, const int numComps, const int
 void polympo_getMPPositions_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, double* mpPositionsIn);
 void polympo_setMPRotLatLon_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, const double* mpRotLatLonIn);
 void polympo_getMPRotLatLon_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, double* mpRotLatLonHost);
-void polympo_setMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, const double* mpVelIn);
-void polympo_getMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, double* mpVelHost);
+void polympo_setMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, const double* uVel, const double* vVel);
+void polympo_getMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, double* uVel, double* vVel);
 
 //Mesh info
 void polympo_startMeshFill_f(MPMesh_ptr p_mpmesh);

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -197,28 +197,32 @@ module polympo
   !> @warning THIS IS NOT SUPPORTED YET 
   !> @param mpmesh(in/out) MPMesh object
   !> @param n(in) half length of array
-  !> @param array(in) input MP velocity 1D array (numMPs*2)
+  !> @param uVelocity(in) input MP velocity 1D array on u-component
+  !> @param vVelocity(in) input MP velocity 1D array on v-component
   !---------------------------------------------------------------------------
-  subroutine polympo_setMPVel(mpMesh, nComps, numMPs, array) &
+  subroutine polympo_setMPVel(mpMesh, nComps, numMPs, uVelocity, vVelocity) &
              bind(C, NAME='polympo_setMPVel_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nComps, numMPs
-    type(c_ptr), intent(in), value :: array
+    type(c_ptr), intent(in), value :: uVelocity, vVelocity
   end subroutine
   !---------------------------------------------------------------------------
   !> @brief get the velocity MP array from a polympo array
   !> @warning THIS IS NOT SUPPORTED YET 
   !> @param mpmesh(in/out) MPMesh object
   !> @param n(in) half length of array
-  !> @param array(in/out) output MP velocity 1D array (numMPs*2), allocated by user
+  !> @param uVelocity(in/out) output MP velocity 1D array on u-component,
+  !>                          allocated by user
+  !> @param vVelocity(in/out) output MP velocity 1D array on v-component,
+  !>                          allocated by user
   !---------------------------------------------------------------------------
-  subroutine polympo_getMPVel(mpMesh, nComps, numMPs, array) &
+  subroutine polympo_getMPVel(mpMesh, nComps, numMPs, uVelocity, vVelocity) &
              bind(C, NAME='polympo_getMPVel_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nComps, numMPs
-    type(c_ptr), value :: array
+    type(c_ptr), value :: uVelocity, vVelocity
   end subroutine
   !---------------------------------------------------------------------------
   !> @brief Enable the setting of mesh topology (number of entities and entity adjacencies). 


### PR DESCRIPTION
Change `polympo_setMPVel` and `polympo_getMPVel` using two 1D u/v velocity arrays instead of a 2D velocity array.