### PR TITLE
Correction: Mesh Velocity change to 2 1D array

### DIFF
--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -588,7 +588,7 @@ void polympo_getMeshVtxRotLat_f(MPMesh_ptr p_mpmesh, const int nVertices, double
   }
 }
 
-void polympo_setMeshVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, const double* array){
+void polympo_setMeshVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, const double* uVelIn, const double* vVelIn){
   //check mpMesh is valid
   checkMPMeshValid(p_mpmesh);
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;
@@ -601,13 +601,13 @@ void polympo_setMeshVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVert
   auto coordsArray = p_mesh->getMeshField<polyMPO::MeshF_Vel>();
   auto h_coordsArray = Kokkos::create_mirror_view(coordsArray);
   for(int i=0; i<nVertices; i++){
-    h_coordsArray(i,0) = array[i*vec2d_nEntries];
-    h_coordsArray(i,1) = array[i*vec2d_nEntries+1];
+    h_coordsArray(i,0) = uVelIn[i];
+    h_coordsArray(i,1) = vVelIn[i];
   }
   Kokkos::deep_copy(coordsArray, h_coordsArray);
 }
 
-void polympo_getMeshVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, double* array){
+void polympo_getMeshVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, double* uVelOut, double* vVelOut){
   //check mpMesh is valid
   checkMPMeshValid(p_mpmesh);
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;
@@ -620,8 +620,8 @@ void polympo_getMeshVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVert
   auto coordsArray = p_mesh->getMeshField<polyMPO::MeshF_Vel>();
   auto h_coordsArray = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),coordsArray);
   for(int i=0; i<nVertices; i++){
-    array[i*vec2d_nEntries] = h_coordsArray(i,0);
-    array[i*vec2d_nEntries+1] = h_coordsArray(i,1);
+    uVelOut[i] = h_coordsArray(i,0);
+    vVelOut[i] = h_coordsArray(i,1);
   }
 }
 

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -229,15 +229,15 @@ void polympo_setMPLatLonRotatedFlag_f(MPMesh_ptr p_mpmesh, const int isRotateFla
 }
 
 void polympo_setMPPositions_f(MPMesh_ptr p_mpmesh,
-                            const int numComps,
+                            const int nComps,
                             const int numMPs,
                             const double* mpPositionsIn){
   checkMPMeshValid(p_mpmesh);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
-  PMT_ALWAYS_ASSERT(numComps == vec3d_nEntries);
+  PMT_ALWAYS_ASSERT(nComps == vec3d_nEntries);
   PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getCount());
   PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getMaxAppID());
-  kkViewHostU<const double**> mpPositionsIn_h(mpPositionsIn,numComps,numMPs);
+  kkViewHostU<const double**> mpPositionsIn_h(mpPositionsIn,nComps,numMPs);
 
   if (p_MPs->rebuildOngoing()) {
     p_MPs->setRebuildMPSlice<polyMPO::MPF_Cur_Pos_XYZ>(mpPositionsIn_h);
@@ -259,12 +259,12 @@ void polympo_setMPPositions_f(MPMesh_ptr p_mpmesh,
 }
 
 void polympo_getMPPositions_f(MPMesh_ptr p_mpmesh,
-                            const int numComps,
+                            const int nComps,
                             const int numMPs,
                             double* mpPositionsHost){
   checkMPMeshValid(p_mpmesh);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
-  PMT_ALWAYS_ASSERT(numComps == vec3d_nEntries);
+  PMT_ALWAYS_ASSERT(nComps == vec3d_nEntries);
   PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getCount());
   PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getMaxAppID());
 
@@ -279,25 +279,25 @@ void polympo_getMPPositions_f(MPMesh_ptr p_mpmesh,
     }
   };
   p_MPs->parallel_for(getPos, "getMPPositions");
-  kkDbl2dViewHostU arrayHost(mpPositionsHost,numComps,numMPs);
+  kkDbl2dViewHostU arrayHost(mpPositionsHost,nComps,numMPs);
   Kokkos::deep_copy(arrayHost, mpPositionsCopy);
 }
 
 void polympo_setMPRotLatLon_f(MPMesh_ptr p_mpmesh,
-                         const int numComps,
+                         const int nComps,
                          const int numMPs,
                          const double* mpRotLatLonIn){
   static int callCount = 0;
   PMT_ALWAYS_ASSERT(callCount == 0);
   checkMPMeshValid(p_mpmesh);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
-  PMT_ALWAYS_ASSERT(numComps == vec2d_nEntries);
+  PMT_ALWAYS_ASSERT(nComps == vec2d_nEntries);
   PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getCount());
   PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getMaxAppID());
 
   auto mpRotLatLon = p_MPs->getData<polyMPO::MPF_Cur_Pos_Rot_Lat_Lon>();
   auto mpAppID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();
-  kkViewHostU<const double**> mpRotLatLonIn_h(mpRotLatLonIn,numComps,numMPs);
+  kkViewHostU<const double**> mpRotLatLonIn_h(mpRotLatLonIn,nComps,numMPs);
   Kokkos::View<double**> mpRotLatLonIn_d("mpRotLatLonDevice",vec2d_nEntries,numMPs);
   Kokkos::deep_copy(mpRotLatLonIn_d, mpRotLatLonIn_h);
   auto setPos = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
@@ -311,12 +311,12 @@ void polympo_setMPRotLatLon_f(MPMesh_ptr p_mpmesh,
 }
 
 void polympo_getMPRotLatLon_f(MPMesh_ptr p_mpmesh,
-                         const int numComps,
+                         const int nComps,
                          const int numMPs,
                          double* mpRotLatLonHost){
   checkMPMeshValid(p_mpmesh);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
-  PMT_ALWAYS_ASSERT(numComps == vec2d_nEntries);
+  PMT_ALWAYS_ASSERT(nComps == vec2d_nEntries);
   PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getCount());
   PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getMaxAppID());
 
@@ -330,20 +330,20 @@ void polympo_getMPRotLatLon_f(MPMesh_ptr p_mpmesh,
     }
   };
   p_MPs->parallel_for(getPos, "getMPRotLatLon");
-  kkDbl2dViewHostU arrayHost(mpRotLatLonHost,numComps,numMPs);
+  kkDbl2dViewHostU arrayHost(mpRotLatLonHost,nComps,numMPs);
   Kokkos::deep_copy(arrayHost, mpRotLatLonCopy);
 }
 
-void polympo_setMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, const double* mpVelIn) {
+void polympo_setMPVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int numMPs, const double* mpVelIn) {
   checkMPMeshValid(p_mpmesh);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
-  PMT_ALWAYS_ASSERT(numComps == vec2d_nEntries);
+  PMT_ALWAYS_ASSERT(nComps == vec2d_nEntries);
   PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getCount());
   PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getMaxAppID());
 
   auto mpVel = p_MPs->getData<polyMPO::MPF_Vel>();
   auto mpAppID = p_MPs->getData<polyMPO::MPF_MP_APP_ID>();
-  kkViewHostU<const double**> mpVelIn_h(mpVelIn,numComps,numMPs);
+  kkViewHostU<const double**> mpVelIn_h(mpVelIn,nComps,numMPs);
   Kokkos::View<double**> mpVelIn_d("mpVelDevice",vec2d_nEntries,numMPs);
   Kokkos::deep_copy(mpVelIn_d, mpVelIn_h);
   auto setMPVel = PS_LAMBDA(const int& elm, const int& mp, const int& mask){
@@ -355,10 +355,10 @@ void polympo_setMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMP
   p_MPs->parallel_for(setMPVel, "setMPVel");
 }
 
-void polympo_getMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, double* mpVelHost) {
+void polympo_getMPVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int numMPs, double* mpVelHost) {
   checkMPMeshValid(p_mpmesh);
   auto p_MPs = ((polyMPO::MPMesh*)p_mpmesh)->p_MPs;
-  PMT_ALWAYS_ASSERT(numComps == vec2d_nEntries);
+  PMT_ALWAYS_ASSERT(nComps == vec2d_nEntries);
   PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getCount());
   PMT_ALWAYS_ASSERT(numMPs >= p_MPs->getMaxAppID());
 
@@ -372,7 +372,7 @@ void polympo_getMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMP
     }
   };
   p_MPs->parallel_for(getMPVel, "getMPVel");
-  kkDbl2dViewHostU arrayHost(mpVelHost,numComps,numMPs);
+  kkDbl2dViewHostU arrayHost(mpVelHost,nComps,numMPs);
   Kokkos::deep_copy(arrayHost, mpVelCopy);
 }
 

--- a/src/pmpo_c.cpp
+++ b/src/pmpo_c.cpp
@@ -588,13 +588,12 @@ void polympo_getMeshVtxRotLat_f(MPMesh_ptr p_mpmesh, const int nVertices, double
   }
 }
 
-void polympo_setMeshVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, const double* uVelIn, const double* vVelIn){
+void polympo_setMeshVel_f(MPMesh_ptr p_mpmesh, const int nVertices, const double* uVelIn, const double* vVelIn){
   //check mpMesh is valid
   checkMPMeshValid(p_mpmesh);
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;
 
   //check the size
-  PMT_ALWAYS_ASSERT(nComps == vec2d_nEntries);
   PMT_ALWAYS_ASSERT(p_mesh->getNumVertices()==nVertices); 
 
   //copy the host array to the device
@@ -607,13 +606,12 @@ void polympo_setMeshVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVert
   Kokkos::deep_copy(coordsArray, h_coordsArray);
 }
 
-void polympo_getMeshVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, double* uVelOut, double* vVelOut){
+void polympo_getMeshVel_f(MPMesh_ptr p_mpmesh, const int nVertices, double* uVelOut, double* vVelOut){
   //check mpMesh is valid
   checkMPMeshValid(p_mpmesh);
   auto p_mesh = ((polyMPO::MPMesh*)p_mpmesh)->p_mesh;
 
   //check the size
-  PMT_ALWAYS_ASSERT(nComps == vec2d_nEntries);
   PMT_ALWAYS_ASSERT(p_mesh->getNumVertices() == nVertices); 
 
   //copy the device array to the host

--- a/src/pmpo_c.h
+++ b/src/pmpo_c.h
@@ -56,8 +56,8 @@ void polympo_setMeshVtxCoords_f(MPMesh_ptr p_mpmesh, const int nVertices, const 
 void polympo_getMeshVtxCoords_f(MPMesh_ptr p_mpmesh, const int nVertices, double* xArray, double* yArray, double* zArray);
 void polympo_setMeshVtxRotLat_f(MPMesh_ptr p_mpmesh, const int nVertices, const double* latitude);
 void polympo_getMeshVtxRotLat_f(MPMesh_ptr p_mpmesh, const int nVertices, double* latitude);
-void polympo_setMeshVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, const double* uVelocity, const double* vVelocity);
-void polympo_getMeshVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, double* uVelocity, double* vVelocity);
+void polympo_setMeshVel_f(MPMesh_ptr p_mpmesh, const int nVertices, const double* uVelocity, const double* vVelocity);
+void polympo_getMeshVel_f(MPMesh_ptr p_mpmesh, const int nVertices, double* uVelocity, double* vVelocity);
 void polympo_setMeshOnSurfVeloIncr_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, const double* array);//vec2d
 void polympo_getMeshOnSurfVeloIncr_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, double* array);//vec2d
 void polympo_setMeshOnSurfDispIncr_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, const double* array);//vec2d

--- a/src/pmpo_c.h
+++ b/src/pmpo_c.h
@@ -56,8 +56,8 @@ void polympo_setMeshVtxCoords_f(MPMesh_ptr p_mpmesh, const int nVertices, const 
 void polympo_getMeshVtxCoords_f(MPMesh_ptr p_mpmesh, const int nVertices, double* xArray, double* yArray, double* zArray);
 void polympo_setMeshVtxRotLat_f(MPMesh_ptr p_mpmesh, const int nVertices, const double* latitude);
 void polympo_getMeshVtxRotLat_f(MPMesh_ptr p_mpmesh, const int nVertices, double* latitude);
-void polympo_setMeshVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, const double* velocity);
-void polympo_getMeshVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, double* velocity);
+void polympo_setMeshVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, const double* uVelocity, const double* vVelocity);
+void polympo_getMeshVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, double* uVelocity, double* vVelocity);
 void polympo_setMeshOnSurfVeloIncr_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, const double* array);//vec2d
 void polympo_getMeshOnSurfVeloIncr_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, double* array);//vec2d
 void polympo_setMeshOnSurfDispIncr_f(MPMesh_ptr p_mpmesh, const int nComps, const int nVertices, const double* array);//vec2d

--- a/src/pmpo_c.h
+++ b/src/pmpo_c.h
@@ -31,8 +31,8 @@ void polympo_setMPPositions_f(MPMesh_ptr p_mpmesh, const int numComps, const int
 void polympo_getMPPositions_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, double* mpPositionsIn);
 void polympo_setMPRotLatLon_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, const double* mpRotLatLonIn);
 void polympo_getMPRotLatLon_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, double* mpRotLatLonHost);
-void polympo_setMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, const double* uVel, const double* vVel);
-void polympo_getMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, double* uVel, double* vVel);
+void polympo_setMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, const double* mpVelIn);
+void polympo_getMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, double* mpVelHost);
 
 //Mesh info
 void polympo_startMeshFill_f(MPMesh_ptr p_mpmesh);

--- a/src/pmpo_c.h
+++ b/src/pmpo_c.h
@@ -27,12 +27,12 @@ void polympo_getMPCurElmID_f(MPMesh_ptr p_mpmesh, const int numMPs, int* elmIDs)
 void polympo_setMPLatLonRotatedFlag_f(MPMesh_ptr p_mpmesh, const int isRotateFlag);
 
 //MP slices
-void polympo_setMPPositions_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, const double* mpPositionsIn);
-void polympo_getMPPositions_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, double* mpPositionsIn);
-void polympo_setMPRotLatLon_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, const double* mpRotLatLonIn);
-void polympo_getMPRotLatLon_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, double* mpRotLatLonHost);
-void polympo_setMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, const double* mpVelIn);
-void polympo_getMPVel_f(MPMesh_ptr p_mpmesh, const int numComps, const int numMPs, double* mpVelHost);
+void polympo_setMPPositions_f(MPMesh_ptr p_mpmesh, const int nComps, const int numMPs, const double* mpPositionsIn);
+void polympo_getMPPositions_f(MPMesh_ptr p_mpmesh, const int nComps, const int numMPs, double* mpPositionsIn);
+void polympo_setMPRotLatLon_f(MPMesh_ptr p_mpmesh, const int nComps, const int numMPs, const double* mpRotLatLonIn);
+void polympo_getMPRotLatLon_f(MPMesh_ptr p_mpmesh, const int nComps, const int numMPs, double* mpRotLatLonHost);
+void polympo_setMPVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int numMPs, const double* mpVelIn);
+void polympo_getMPVel_f(MPMesh_ptr p_mpmesh, const int nComps, const int numMPs, double* mpVelHost);
 
 //Mesh info
 void polympo_startMeshFill_f(MPMesh_ptr p_mpmesh);

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -197,32 +197,28 @@ module polympo
   !> @warning THIS IS NOT SUPPORTED YET 
   !> @param mpmesh(in/out) MPMesh object
   !> @param n(in) half length of array
-  !> @param uVelocity(in) input MP velocity 1D array on u-component
-  !> @param vVelocity(in) input MP velocity 1D array on v-component
+  !> @param array(in) input MP velocity 1D array (numMPs*2)
   !---------------------------------------------------------------------------
-  subroutine polympo_setMPVel(mpMesh, nComps, numMPs, uVelocity, vVelocity) &
+  subroutine polympo_setMPVel(mpMesh, nComps, numMPs, array) &
              bind(C, NAME='polympo_setMPVel_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nComps, numMPs
-    type(c_ptr), intent(in), value :: uVelocity, vVelocity
+    type(c_ptr), intent(in), value :: array
   end subroutine
   !---------------------------------------------------------------------------
   !> @brief get the velocity MP array from a polympo array
   !> @warning THIS IS NOT SUPPORTED YET 
   !> @param mpmesh(in/out) MPMesh object
   !> @param n(in) half length of array
-  !> @param uVelocity(in/out) output MP velocity 1D array on u-component,
-  !>                          allocated by user
-  !> @param vVelocity(in/out) output MP velocity 1D array on v-component,
-  !>                          allocated by user
+  !> @param array(in/out) output MP velocity 1D array (numMPs*2), allocated by user
   !---------------------------------------------------------------------------
-  subroutine polympo_getMPVel(mpMesh, nComps, numMPs, uVelocity, vVelocity) &
+  subroutine polympo_getMPVel(mpMesh, nComps, numMPs, array) &
              bind(C, NAME='polympo_getMPVel_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nComps, numMPs
-    type(c_ptr), value :: uVelocity, vVelocity
+    type(c_ptr), value :: array
   end subroutine
   !---------------------------------------------------------------------------
   !> @brief Enable the setting of mesh topology (number of entities and entity adjacencies). 

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -196,7 +196,8 @@ module polympo
   !> @brief set the velocity MP array from a host array
   !> @warning THIS IS NOT SUPPORTED YET 
   !> @param mpmesh(in/out) MPMesh object
-  !> @param n(in) half length of array
+  !> @param nComps(in) number of components, should always be 2
+  !> @param numMPs(in) number of the MPs
   !> @param array(in) input MP velocity 1D array (numMPs*2)
   !---------------------------------------------------------------------------
   subroutine polympo_setMPVel(mpMesh, nComps, numMPs, array) &
@@ -210,7 +211,8 @@ module polympo
   !> @brief get the velocity MP array from a polympo array
   !> @warning THIS IS NOT SUPPORTED YET 
   !> @param mpmesh(in/out) MPMesh object
-  !> @param n(in) half length of array
+  !> @param nComps(in) number of components, should always be 2
+  !> @param numMPs(in) number of the MPs
   !> @param array(in/out) output MP velocity 1D array (numMPs*2), allocated by user
   !---------------------------------------------------------------------------
   subroutine polympo_getMPVel(mpMesh, nComps, numMPs, array) &

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -194,7 +194,6 @@ module polympo
   end subroutine
   !---------------------------------------------------------------------------
   !> @brief set the velocity MP array from a host array
-  !> @warning THIS IS NOT SUPPORTED YET 
   !> @param mpmesh(in/out) MPMesh object
   !> @param nComps(in) number of components, should always be 2
   !> @param numMPs(in) number of the MPs
@@ -209,7 +208,6 @@ module polympo
   end subroutine
   !---------------------------------------------------------------------------
   !> @brief get the velocity MP array from a polympo array
-  !> @warning THIS IS NOT SUPPORTED YET 
   !> @param mpmesh(in/out) MPMesh object
   !> @param nComps(in) number of components, should always be 2
   !> @param numMPs(in) number of the MPs

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -449,29 +449,32 @@ module polympo
   !> @param mpmesh(in/out) MPMesh object
   !> @param nComps(in) number of components, should always be 2
   !> @param nVertices(in) numVertices
-  !> @param array(in) input vertices velocity 2D array (2,numVtx)
+  !> @param uVel(in) vertices u-component velocity 1D array (numVtx)
+  !> @param vVel(in) vertices v-component velocity 1D array (numVtx)
   !---------------------------------------------------------------------------
-  subroutine polympo_setMeshVel(mpMesh, nComps, nVertices, array) &
+  subroutine polympo_setMeshVel(mpMesh, nComps, nVertices, uVel, vVel) &
              bind(C, NAME='polympo_setMeshVel_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nComps, nVertices
-    type(c_ptr), intent(in), value :: array
+    type(c_ptr), intent(in), value :: uVel, vVel
   end subroutine
   !---------------------------------------------------------------------------
   !> @brief get the vertices velocity from polyMPO
   !> @param mpmesh(in/out) MPMesh object
   !> @param nComps(in) number of components, should always be 2
   !> @param nVertices(in) numVertices
-  !> @param array(in/out) output vertices velocity
-  !>        2D array (2,numVtx), allocated by user
+  !> @param uVel(in/out) output vertices u-component velocity
+  !>        1D array (numVtx), allocated by user
+  !> @param vVel(in/out) output vertices v-component velocity
+  !>        1D array (numVtx), allocated by user
   !---------------------------------------------------------------------------
-  subroutine polympo_getMeshVel(mpMesh, nComps, nVertices, array) &
+  subroutine polympo_getMeshVel(mpMesh, nComps, nVertices, uVel, vVel) &
              bind(C, NAME='polympo_getMeshVel_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
     integer(c_int), value :: nComps, nVertices
-    type(c_ptr), value :: array
+    type(c_ptr), value :: uVel, vVel
   end subroutine
   !---------------------------------------------------------------------------
   !> @brief set the spherical velocity increment mesh array 

--- a/src/pmpo_fortran.f90
+++ b/src/pmpo_fortran.f90
@@ -447,33 +447,31 @@ module polympo
   !---------------------------------------------------------------------------
   !> @brief set the vertices velocity from a host array
   !> @param mpmesh(in/out) MPMesh object
-  !> @param nComps(in) number of components, should always be 2
   !> @param nVertices(in) numVertices
   !> @param uVel(in) vertices u-component velocity 1D array (numVtx)
   !> @param vVel(in) vertices v-component velocity 1D array (numVtx)
   !---------------------------------------------------------------------------
-  subroutine polympo_setMeshVel(mpMesh, nComps, nVertices, uVel, vVel) &
+  subroutine polympo_setMeshVel(mpMesh, nVertices, uVel, vVel) &
              bind(C, NAME='polympo_setMeshVel_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
-    integer(c_int), value :: nComps, nVertices
+    integer(c_int), value :: nVertices
     type(c_ptr), intent(in), value :: uVel, vVel
   end subroutine
   !---------------------------------------------------------------------------
   !> @brief get the vertices velocity from polyMPO
   !> @param mpmesh(in/out) MPMesh object
-  !> @param nComps(in) number of components, should always be 2
   !> @param nVertices(in) numVertices
   !> @param uVel(in/out) output vertices u-component velocity
   !>        1D array (numVtx), allocated by user
   !> @param vVel(in/out) output vertices v-component velocity
   !>        1D array (numVtx), allocated by user
   !---------------------------------------------------------------------------
-  subroutine polympo_getMeshVel(mpMesh, nComps, nVertices, uVel, vVel) &
+  subroutine polympo_getMeshVel(mpMesh, nVertices, uVel, vVel) &
              bind(C, NAME='polympo_getMeshVel_f')
     use :: iso_c_binding
     type(c_ptr), value :: mpMesh
-    integer(c_int), value :: nComps, nVertices
+    integer(c_int), value :: nVertices
     type(c_ptr), value :: uVel, vVel
   end subroutine
   !---------------------------------------------------------------------------

--- a/test/testFortran.f90
+++ b/test/testFortran.f90
@@ -132,10 +132,10 @@ program main
     yArray(i) = value2 - i
   end do 
   write(*,*) xArray, yArray
-  call polympo_setMeshVel(mpMesh, numCompsVel, nverts, c_loc(xArray),c_loc(yArray))
+  call polympo_setMeshVel(mpMesh, nverts, c_loc(xArray),c_loc(yArray))
   xArray = -1
   yArray = -1
-  call polympo_getMeshVel(mpMesh, numCompsVel, nverts, c_loc(xArray),c_loc(yArray))
+  call polympo_getMeshVel(mpMesh, nverts, c_loc(xArray),c_loc(yArray))
   write(*,*) xArray, yArray
   do i = 1, nverts
     call assert((xArray(i) .eq. i+value1), "Assert MeshVel u-component Velocity Fail")

--- a/test/testFortran.f90
+++ b/test/testFortran.f90
@@ -131,12 +131,10 @@ program main
     xArray(i) = i + value1
     yArray(i) = value2 - i
   end do 
-  write(*,*) xArray, yArray
   call polympo_setMeshVel(mpMesh, nverts, c_loc(xArray),c_loc(yArray))
   xArray = -1
   yArray = -1
   call polympo_getMeshVel(mpMesh, nverts, c_loc(xArray),c_loc(yArray))
-  write(*,*) xArray, yArray
   do i = 1, nverts
     call assert((xArray(i) .eq. i+value1), "Assert MeshVel u-component Velocity Fail")
     call assert((yArray(i) .eq. value2-i), "Assert MeshVel v-component Velocity Fail")

--- a/test/testFortran.f90
+++ b/test/testFortran.f90
@@ -93,18 +93,10 @@ program main
         Mesharray(i,j) = (i-1)*nverts + j
     end do
   end do
-  call polympo_setMeshVel(mpMesh, numCompsVel, nverts, c_loc(Mesharray))
   call polympo_setMeshOnSurfVeloIncr(mpMesh, numCompsVel, nverts, c_loc(Mesharray))
   call polympo_setMeshOnSurfDispIncr(mpMesh, numCompsVel, nverts, c_loc(Mesharray))
 
   ! check mesh Fields
-  Mesharray = -1
-  call polympo_getMeshVel(mpMesh, numCompsVel, nverts, c_loc(Mesharray))
-  do i = 1,numCompsVel
-    do j = 1,nverts 
-        call assert((Mesharray(i,j) .eq. (i-1)*nverts+j), "Assert MeshVel Fail")
-    end do
-  end do
   Mesharray = -1
   call polympo_getMeshOnSurfVeloIncr(mpMesh, numCompsVel, nverts, c_loc(Mesharray))
   do i = 1,numCompsVel
@@ -133,6 +125,22 @@ program main
   call assert(all(xArray .eq. value1), "Assert xArray == value1 Failed!")
   call assert(all(yArray .eq. value2), "Assert yArray == value2 Failed!")
   call assert(all(zArray .eq. value1 + value2), "Assert zArray == value1 + value2 Failed!")
+
+  !use xArray and yArrray to hold u and v components 
+  do i = 1, nverts
+    xArray(i) = i + value1
+    yArray(i) = value2 - i
+  end do 
+  write(*,*) xArray, yArray
+  call polympo_setMeshVel(mpMesh, numCompsVel, nverts, c_loc(xArray),c_loc(yArray))
+  xArray = -1
+  yArray = -1
+  call polympo_getMeshVel(mpMesh, numCompsVel, nverts, c_loc(xArray),c_loc(yArray))
+  write(*,*) xArray, yArray
+  do i = 1, nverts
+    call assert((xArray(i) .eq. i+value1), "Assert MeshVel u-component Velocity Fail")
+    call assert((yArray(i) .eq. value2-i), "Assert MeshVel v-component Velocity Fail")
+  end do 
 
   deallocate(MParray)
   deallocate(Mesharray)


### PR DESCRIPTION
- revert the changes in https://github.com/SCOREC/polyMPO/pull/56
- Change `polympo_setMeshVel` and `polympo_getMeshVel` using two 1D u/v velocity arrays instead of a 2D velocity array.